### PR TITLE
Remove Delay

### DIFF
--- a/feather/examples/connect_network.rs
+++ b/feather/examples/connect_network.rs
@@ -24,7 +24,6 @@ fn program() -> Result<(), StackError> {
         let mut cnt = create_countdowns(&delay_tick);
 
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
         let ssid = option_env!("TEST_SSID").unwrap_or(DEFAULT_TEST_SSID);
         let password = option_env!("TEST_PASSWORD").unwrap_or(DEFAULT_TEST_PASSWORD);
@@ -33,7 +32,7 @@ fn program() -> Result<(), StackError> {
             ssid,
             password
         );
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/connect_saved.rs
+++ b/feather/examples/connect_saved.rs
@@ -21,10 +21,9 @@ fn program() -> Result<(), StackError> {
         let mut cnt = create_countdowns(&ini.delay_tick);
 
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
         defmt::info!("Connecting to saved network ..",);
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/http_server.rs
+++ b/feather/examples/http_server.rs
@@ -27,7 +27,6 @@ fn program() -> Result<(), StackError> {
         let red_led = &mut ini.red_led;
 
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
         let ssid = option_env!("TEST_SSID").unwrap_or(DEFAULT_TEST_SSID);
         let password = option_env!("TEST_PASSWORD").unwrap_or(DEFAULT_TEST_PASSWORD);
@@ -36,7 +35,7 @@ fn program() -> Result<(), StackError> {
             ssid,
             password
         );
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/iperf3_client.rs
+++ b/feather/examples/iperf3_client.rs
@@ -105,10 +105,9 @@ where
         let mut cnt = create_countdowns(&ini.delay_tick);
 
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
         defmt::info!("Connecting to saved network ..",);
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/ping.rs
+++ b/feather/examples/ping.rs
@@ -26,11 +26,10 @@ fn program() -> Result<(), StackError> {
         let red_led = &mut ini.red_led;
 
         let mut cnt = create_countdowns(&ini.delay_tick);
-        let mut delay1 = delay_fn(&mut cnt.0);
         let mut delay_ms = delay_fn(&mut cnt.1);
 
         defmt::info!("Connecting to saved network ..",);
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay1);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/runner/mod.rs
+++ b/feather/examples/runner/mod.rs
@@ -55,9 +55,8 @@ pub fn connect_and_run(
         let red_led = &mut ini.red_led;
 
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/scan.rs
+++ b/feather/examples/scan.rs
@@ -19,9 +19,8 @@ fn program() -> Result<(), StackError> {
 
         let mut cnt = create_countdowns(&ini.delay_tick);
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/examples/telnet_shell.rs
+++ b/feather/examples/telnet_shell.rs
@@ -18,10 +18,9 @@ fn program() -> Result<(), StackError> {
         let mut cnt = create_countdowns(&ini.delay_tick);
 
         let mut delay_ms = delay_fn(&mut cnt.0);
-        let mut delay_ms2 = delay_fn(&mut cnt.1);
 
         defmt::info!("Connecting to saved network ..",);
-        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi), &mut delay_ms2);
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
 
         let mut v = 0;
         loop {

--- a/feather/src/shared/spi_stream.rs
+++ b/feather/src/shared/spi_stream.rs
@@ -83,4 +83,7 @@ impl<CS: AnyPin, Spi: SpiBus> Transfer for SpiStream<CS, Spi> {
     fn switch_to_high_speed(&mut self) {
         self.set_wait_cycles(FAST_WAIT_CYCLES);
     }
+    fn delay(&mut self, delay: u32) {
+        cortex_m::asm::delay(delay * 100_000);
+    }
 }

--- a/winc-rs/src/client/dns.rs
+++ b/winc-rs/src/client/dns.rs
@@ -67,8 +67,7 @@ mod tests {
 
     #[test]
     fn test_get_host_by_name_success() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_resolve(Ipv4Addr::new(127, 0, 0, 1), "");
         };
@@ -78,15 +77,13 @@ mod tests {
     }
     #[test]
     fn test_get_host_by_name_timeout() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let result = nb::block!(client.get_host_by_name("example.com", AddrType::IPv4));
         assert_eq!(result.err(), Some(StackError::DnsTimeout.into()));
     }
     #[test]
     fn test_get_host_by_name_failed() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_resolve(Ipv4Addr::new(0, 0, 0, 0), "");
         };
@@ -98,16 +95,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_get_host_by_name_unsupported_addr_type() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let _ = client.get_host_by_name("example.com", AddrType::IPv6);
     }
 
     #[test]
     #[should_panic]
     fn test_get_host_by_address() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let _ = client.get_host_by_address(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), &mut [0; 4]);
     }
 }

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -76,7 +76,7 @@ impl<X: Xfer> WincClient<'_, X> {
                 Err(nb::Error::WouldBlock)
             }
             WifiModuleState::ConnectingToAp => {
-                (self.delay)(1); // absolute minimum delay to make timeout possible
+                self.delay(1); // absolute minimum delay to make timeout possible
                 self.dispatch_events()?;
                 self.operation_countdown -= 1;
                 if self.operation_countdown == 0 {
@@ -310,14 +310,12 @@ mod tests {
 
     #[test]
     fn test_heartbeat() {
-        let mut delay = |_| {};
-        assert_eq!(make_test_client(&mut delay).heartbeat(), Ok(()));
+        assert_eq!(make_test_client().heartbeat(), Ok(()));
     }
 
     #[test]
     fn test_start_wifi_module() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let result = nb::block!(client.start_wifi_module());
         assert_eq!(
             result,
@@ -327,23 +325,20 @@ mod tests {
 
     #[test]
     fn test_connect_to_saved_ap_invalid_state() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         let result = nb::block!(client.connect_to_saved_ap());
         assert_eq!(result, Err(StackError::InvalidState));
     }
     #[test]
     fn test_connect_to_saved_ap_timeout() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let result = nb::block!(client.connect_to_saved_ap());
         assert_eq!(result, Err(StackError::GeneralTimeout));
     }
     #[test]
     fn test_connect_to_saved_ap_success() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_connstate_changed(WifiConnState::Connected, WifiConnError::Unhandled);
@@ -354,8 +349,7 @@ mod tests {
     }
     #[test]
     fn test_connect_to_saved_ap_invalid_credentials() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_connstate_changed(WifiConnState::Disconnected, WifiConnError::AuthFail);
@@ -370,8 +364,7 @@ mod tests {
 
     #[test]
     fn test_connect_to_ap_success() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_connstate_changed(WifiConnState::Connected, WifiConnError::Unhandled);
@@ -383,8 +376,7 @@ mod tests {
 
     #[test]
     fn test_scan_ok() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_scan_done(5, WifiConnError::Unhandled);
@@ -396,8 +388,7 @@ mod tests {
 
     #[test]
     fn test_get_scan_result_ok() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_scan_result(ScanResult {
@@ -416,8 +407,7 @@ mod tests {
 
     #[test]
     fn test_get_current_rssi_ok() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_rssi(0);
@@ -429,8 +419,7 @@ mod tests {
 
     #[test]
     fn test_get_connection_info_ok() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_connection_info(ConnectionInfo {
@@ -448,8 +437,7 @@ mod tests {
 
     #[test]
     fn test_get_firmware_version_ok() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let result = client.get_firmware_version();
         assert_eq!(result.unwrap().chip_id, 0);
@@ -457,8 +445,7 @@ mod tests {
 
     #[test]
     fn test_send_ping_ok() {
-        let mut delay = |_| {};
-        let mut client = make_test_client(&mut delay);
+        let mut client = make_test_client();
         client.callbacks.state = WifiModuleState::Started;
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_ping(

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -37,12 +37,10 @@
 //! # use wincwifi::WincClient;
 //! # use embedded_nal::{nb, AddrType, Dns};
 //! # fn del_fn(ms: u32) {}
-//! # let mut delay_fn = del_fn;
 //! # let mut buffer = [0; 1];
 //! # let mut spi = buffer.as_mut_slice();
 //! // spi: something that implements the protocol transfer
-//! // delay_fn: a callback function that lets the library wait
-//! let mut client = WincClient::new(spi, &mut delay_fn);
+//! let mut client = WincClient::new(spi);
 //! nb::block!(client.start_wifi_module());
 //! nb::block!(client.connect_to_ap("ssid", "password", false));
 //! nb::block!(client.get_host_by_name("google.com", AddrType::IPv4));

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -173,6 +173,10 @@ impl<X: Xfer> Manager<X> {
     pub fn set_unit_test_mode(&mut self) {
         self.chip.set_unit_test_mode();
     }
+    // Todo: remove this
+    pub fn delay(&mut self, delay: u32) {
+        self.chip.delay(delay);
+    }
 
     pub fn set_crc_state(&mut self, value: bool) {
         self.chip.crc = value;

--- a/winc-rs/src/manager/chip_access.rs
+++ b/winc-rs/src/manager/chip_access.rs
@@ -69,6 +69,10 @@ impl<X: Xfer> ChipAccess<X> {
         self.verify = false;
         self.check_crc = false;
     }
+    // Todo: remove this
+    pub fn delay(&mut self, delay: u32) {
+        self.xfer.delay(delay);
+    }
 
     fn protocol_verify(
         &mut self,

--- a/winc-rs/src/transfer.rs
+++ b/winc-rs/src/transfer.rs
@@ -31,6 +31,9 @@ pub trait Xfer {
     /// Optionally reduce bus wait times after initialization.
     /// This speeds up the overall communications
     fn switch_to_high_speed(&mut self) {}
+    /// Optional delay, roughly in milliseconds
+    /// Note/TODO: This will be deprecated
+    fn delay(&mut self, _delay: u32) {}
 }
 
 // Blanket implementation


### PR DESCRIPTION
Issue #35
Removes delay argument. However the "solution" at the moment is still quite hackish: it pushed the delay to Transfer trait.

And the implementation just wings it, without tracking the actual time.

Long term solution is not to have any delays at all, and delegate waits fully to caller.