### PR TITLE
Make connect behave in correct non-blocking way

### DIFF
--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -163,7 +163,7 @@ impl<X: Xfer> WincClient<'_, X> {
         .map_err(|e| {
             if matches!(e, StackError::GeneralTimeout) {
                 match expect_op {
-                    ClientSocketOp::Connect => StackError::ConnectTimeout,
+                    ClientSocketOp::Connect(_) => StackError::ConnectTimeout,
                     ClientSocketOp::Send(_) => StackError::SendTimeout,
                     ClientSocketOp::Recv => StackError::RecvTimeout,
                     _ => StackError::GeneralTimeout,

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -1,5 +1,4 @@
 use crate::manager::Manager;
-use crate::socket::Socket;
 use crate::transfer::Xfer;
 
 use crate::manager::SocketError;
@@ -19,7 +18,6 @@ pub use crate::stack::socket_callbacks::{Handle, PingResult};
 
 pub enum GenResult {
     Len(usize),
-    Accept(core::net::SocketAddrV4, Socket),
 }
 
 /// Client for the WincWifi chip.
@@ -45,7 +43,6 @@ impl<X: Xfer> WincClient<'_, X> {
 
     const TCP_SOCKET_BACKLOG: u8 = 4;
     const LISTEN_TIMEOUT: u32 = 100;
-    const ACCEPT_TIMEOUT: u32 = 100;
     const BIND_TIMEOUT: u32 = 100;
     const SEND_TIMEOUT: u32 = 1000;
     const RECV_TIMEOUT: u32 = 1000;
@@ -129,7 +126,6 @@ impl<X: Xfer> WincClient<'_, X> {
         timeout: u32,
         tcp: bool,
     ) -> Result<GenResult, StackError> {
-        self.callbacks.last_accept_addr = None;
         self.callbacks.last_error = SocketError::NoError;
 
         debug!("===>Waiting for op ack for {:?}", expect_op);
@@ -146,13 +142,6 @@ impl<X: Xfer> WincClient<'_, X> {
                     expect_op, client.callbacks.recv_len, elapsed
                 );
 
-                if let Some(accepted_socket) = client.callbacks.last_accepted_socket.take() {
-                    return Some(Ok(GenResult::Accept(
-                        client.callbacks.last_accept_addr.unwrap(),
-                        accepted_socket,
-                    )));
-                }
-
                 if client.callbacks.last_error != SocketError::NoError {
                     return Some(Err(StackError::OpFailed(client.callbacks.last_error)));
                 }
@@ -163,7 +152,6 @@ impl<X: Xfer> WincClient<'_, X> {
         .map_err(|e| {
             if matches!(e, StackError::GeneralTimeout) {
                 match expect_op {
-                    ClientSocketOp::Connect(_) => StackError::ConnectTimeout,
                     ClientSocketOp::Send(_) => StackError::SendTimeout,
                     ClientSocketOp::Recv => StackError::RecvTimeout,
                     _ => StackError::GeneralTimeout,

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -16,6 +16,7 @@ pub use crate::stack::socket_callbacks::ClientSocketOp;
 use crate::stack::socket_callbacks::SocketCallbacks;
 pub use crate::stack::socket_callbacks::{Handle, PingResult};
 
+// Todo: Delete this and replace with per-socket enum values in ClientSocketOp
 pub enum GenResult {
     Len(usize),
 }

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -135,13 +135,25 @@ impl<X: Xfer> UdpFullStack for WincClient<'_, X> {
         let server_addr =
             core::net::SocketAddrV4::new(core::net::Ipv4Addr::new(0, 0, 0, 0), local_port);
         let (sock, op) = self.callbacks.udp_sockets.get(*socket).unwrap();
-        *op = ClientSocketOp::Bind;
-        let op = *op;
+        *op = ClientSocketOp::Bind(None);
+        debug!("<> Sending UDP socket bind to {:?}", sock);
         self.manager
             .send_bind(*sock, server_addr)
             .map_err(StackError::BindFailed)?;
-        self.wait_for_op_ack(*socket, op, Self::BIND_TIMEOUT, false)?;
-        Ok(())
+        self.wait_with_timeout(Self::BIND_TIMEOUT, |client, _| {
+            let (_, op) = client.callbacks.udp_sockets.get(*socket).unwrap();
+            let res = match op {
+                ClientSocketOp::Bind(Some(bind_result)) => match bind_result.error {
+                    SocketError::NoError => Some(Ok(())),
+                    _ => Some(Err(StackError::OpFailed(bind_result.error))),
+                },
+                _ => None,
+            };
+            if res.is_some() {
+                *op = ClientSocketOp::None;
+            }
+            res
+        })
     }
 
     fn send_to(

--- a/winc-rs/src/stack/stack_error.rs
+++ b/winc-rs/src/stack/stack_error.rs
@@ -37,6 +37,10 @@ pub enum StackError {
     ApJoinFailed(WifiConnError),
     /// Scan operation failed
     ApScanFailed(WifiConnError),
+    /// Internal for delaying
+    CallDelay,
+    /// Dispatch event
+    Dispatch,
 }
 
 impl From<core::convert::Infallible> for StackError {


### PR DESCRIPTION
Fixes connect, listen, bind and accept. 

Connect and Accept now behave properly, returning EWouldblock in a loop. Each of those also now owns gets its own results from callbacks, so sockets don't get mixed up.

Same still needs to be done for send/recv too.