### PR TITLE
Added Unit Test Cases for `Client` Module

### DIFF
--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -38,6 +38,10 @@ pub struct WincClient<'a, X: Xfer> {
 
 impl<X: Xfer> WincClient<'_, X> {
     // Max send frame length
+    #[cfg(not(test))]
+    const MAX_SEND_LENGTH: usize = 1400;
+
+    #[cfg(test)]
     const MAX_SEND_LENGTH: usize = 1400;
 
     const TCP_SOCKET_BACKLOG: u8 = 4;

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -42,7 +42,7 @@ impl<X: Xfer> WincClient<'_, X> {
     const MAX_SEND_LENGTH: usize = 1400;
 
     #[cfg(test)]
-    const MAX_SEND_LENGTH: usize = 1400;
+    const MAX_SEND_LENGTH: usize = 4;
 
     const TCP_SOCKET_BACKLOG: u8 = 4;
     const LISTEN_TIMEOUT: u32 = 100;

--- a/winc-rs/src/client/tcp_stack.rs
+++ b/winc-rs/src/client/tcp_stack.rs
@@ -420,13 +420,13 @@ mod test {
         let mut tcp_socket = client.socket().unwrap();
         let socket_addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80);
         let mut recv_buff = [0u8; 32];
-        let test_data = "Hello, World".as_bytes();
+        let test_data = "1234".as_bytes();
 
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_recv(
                 Socket::new(0, 0),
                 socket_addr,
-                &test_data[..SOCKET_BUFFER_MAX_LENGTH],
+                &test_data,
                 SocketError::NoError,
             );
         };
@@ -435,11 +435,8 @@ mod test {
 
         let result = nb::block!(client.receive(&mut tcp_socket, &mut recv_buff));
 
-        assert_eq!(result.ok(), Some(SOCKET_BUFFER_MAX_LENGTH));
-        assert_eq!(
-            &recv_buff[..SOCKET_BUFFER_MAX_LENGTH],
-            &test_data[..SOCKET_BUFFER_MAX_LENGTH]
-        );
+        assert_eq!(result.ok(), Some(test_data.len()));
+        assert_eq!(&recv_buff[..test_data.len()], test_data);
     }
 
     #[test]

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -253,3 +253,215 @@ impl<X: Xfer> UdpFullStack for WincClient<'_, X> {
         self.send_udp_inner(socket, addr, data)
     }
 }
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use crate::client::{self, test_shared::*};
+    use crate::{
+        client::SocketCallbacks,
+        manager::{EventListener, SOCKET_BUFFER_MAX_LENGTH},
+        socket::Socket,
+    };
+    use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
+    use embedded_nal::{UdpClientStack, UdpFullStack};
+
+    #[test]
+    fn test_udp_socket_open() {
+        let mut client = make_test_client();
+        let udp_socket = client.socket();
+        assert!(udp_socket.is_ok());
+    }
+
+    #[test]
+    fn test_udp_connect() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80);
+
+        let result = client.connect(&mut udp_socket, socket_addr);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_udp_connect_v6_failure() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+
+        let socket_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 80);
+
+        let _ = client.connect(&mut udp_socket, socket_addr);
+    }
+
+    #[test]
+    fn test_udp_send() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+        let packet = "Hello, World";
+
+        // Connect to address
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80);
+        let result = client.connect(&mut udp_socket, socket_addr);
+        assert!(result.is_ok());
+
+        // set callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_send_to(Socket::new(7, 0), packet.len() as i16);
+        };
+        client.debug_callback = Some(&mut my_debug);
+
+        // call send
+        let result = nb::block!(client.send(&mut udp_socket, packet.as_bytes()));
+
+        assert_eq!(result.ok(), Some(()));
+    }
+
+    #[test]
+    fn test_udp_receive() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+        let _ipv4 = Ipv4Addr::new(127, 0, 0, 1);
+        let socket_addr_v4 = SocketAddrV4::new(_ipv4, 80);
+        let mut recv_buff = [0u8; 32];
+        let test_data = "1234".as_bytes();
+
+        // Connect to address
+        let socket_addr = SocketAddr::new(IpAddr::V4(_ipv4), 80);
+        let result = client.connect(&mut udp_socket, socket_addr);
+        assert!(result.is_ok());
+
+        // set callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_recvfrom(
+                Socket::new(7, 0),
+                socket_addr_v4,
+                &test_data,
+                SocketError::NoError,
+            );
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+
+        // call recieve
+        let result = nb::block!(client.receive(&mut udp_socket, &mut recv_buff));
+
+        assert_eq!(result.ok(), Some((test_data.len(), socket_addr)));
+        assert_eq!(&recv_buff[..test_data.len()], test_data);
+    }
+
+    #[test]
+    fn test_udp_close() {
+        let mut client = make_test_client();
+        let udp_socket = client.socket().unwrap();
+
+        let result = client.close(udp_socket);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_udp_bind() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_bind(Socket::new(7, 0), SocketError::NoError);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+
+        let result = client.bind(&mut udp_socket, 8080);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_udp_send_to() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+        let packet = "Hello, World";
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80);
+
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_send_to(Socket::new(7, 0), packet.len() as i16);
+        };
+        client.debug_callback = Some(&mut my_debug);
+
+        let result = nb::block!(client.send_to(&mut udp_socket, socket_addr, packet.as_bytes()));
+
+        assert_eq!(result.ok(), Some(()));
+    }
+
+    #[test]
+    fn test_udp_check_max_send_buffer() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+        let packet = "Hello, World";
+        let socket = Socket::new(7, 0);
+        let valid_len: i16 = client::WincClient::<'_, MockTransfer>::MAX_SEND_LENGTH as i16;
+
+        // Connect to address
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80);
+        let result = client.connect(&mut udp_socket, socket_addr);
+        assert!(result.is_ok());
+
+        // set callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_send_to(socket, valid_len);
+        };
+        client.debug_callback = Some(&mut my_debug);
+
+        // call send
+        let result = client.send(&mut udp_socket, packet.as_bytes());
+
+        assert_eq!(result, Err(nb::Error::WouldBlock));
+
+        if let Some((_, ClientSocketOp::AsyncOp(AsyncOp::SendTo(req, _), _))) =
+            client.callbacks.resolve(socket)
+        {
+            assert!((req.total_sent == valid_len) && (req.remaining == 0 as i16));
+        } else {
+            assert!(false, "Expected Some value, but it returned None");
+        }
+    }
+
+    #[test]
+    fn test_udp_check_max_rcv_buffer() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+        let _ipv4 = Ipv4Addr::new(127, 0, 0, 1);
+        let socket_addr_v4 = SocketAddrV4::new(_ipv4, 80);
+        let mut recv_buff = [0u8; 32];
+        let test_data = "Hello, World".as_bytes();
+
+        // Connect to address
+        let socket_addr = SocketAddr::new(IpAddr::V4(_ipv4), 80);
+        let result = client.connect(&mut udp_socket, socket_addr);
+        assert!(result.is_ok());
+
+        // set callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_recvfrom(
+                Socket::new(7, 0),
+                socket_addr_v4,
+                &test_data[..test_data.len().min(SOCKET_BUFFER_MAX_LENGTH)],
+                SocketError::NoError,
+            );
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+
+        // call recieve
+        let result = client.receive(&mut udp_socket, &mut recv_buff);
+
+        assert_eq!(result.err(), Some(nb::Error::WouldBlock));
+        assert_eq!(
+            &client.callbacks.recv_buffer,
+            &test_data[..SOCKET_BUFFER_MAX_LENGTH]
+        );
+    }
+}

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -259,11 +259,7 @@ mod test {
 
     use super::*;
     use crate::client::{self, test_shared::*};
-    use crate::{
-        client::SocketCallbacks,
-        manager::{EventListener, SOCKET_BUFFER_MAX_LENGTH},
-        socket::Socket,
-    };
+    use crate::{client::SocketCallbacks, manager::EventListener, socket::Socket};
     use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
     use embedded_nal::{UdpClientStack, UdpFullStack};
 
@@ -327,7 +323,7 @@ mod test {
         let _ipv4 = Ipv4Addr::new(127, 0, 0, 1);
         let socket_addr_v4 = SocketAddrV4::new(_ipv4, 80);
         let mut recv_buff = [0u8; 32];
-        let test_data = "1234".as_bytes();
+        let test_data = "Hello, World".as_bytes();
 
         // Connect to address
         let socket_addr = SocketAddr::new(IpAddr::V4(_ipv4), 80);
@@ -427,41 +423,5 @@ mod test {
         } else {
             assert!(false, "Expected Some value, but it returned None");
         }
-    }
-
-    #[test]
-    fn test_udp_check_max_rcv_buffer() {
-        let mut client = make_test_client();
-        let mut udp_socket = client.socket().unwrap();
-        let _ipv4 = Ipv4Addr::new(127, 0, 0, 1);
-        let socket_addr_v4 = SocketAddrV4::new(_ipv4, 80);
-        let mut recv_buff = [0u8; 32];
-        let test_data = "Hello, World".as_bytes();
-
-        // Connect to address
-        let socket_addr = SocketAddr::new(IpAddr::V4(_ipv4), 80);
-        let result = client.connect(&mut udp_socket, socket_addr);
-        assert!(result.is_ok());
-
-        // set callback
-        let mut my_debug = |callbacks: &mut SocketCallbacks| {
-            callbacks.on_recvfrom(
-                Socket::new(7, 0),
-                socket_addr_v4,
-                &test_data[..test_data.len().min(SOCKET_BUFFER_MAX_LENGTH)],
-                SocketError::NoError,
-            );
-        };
-
-        client.debug_callback = Some(&mut my_debug);
-
-        // call recieve
-        let result = client.receive(&mut udp_socket, &mut recv_buff);
-
-        assert_eq!(result.err(), Some(nb::Error::WouldBlock));
-        assert_eq!(
-            &client.callbacks.recv_buffer,
-            &test_data[..SOCKET_BUFFER_MAX_LENGTH]
-        );
     }
 }

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -81,7 +81,11 @@ const ETHERNET_HEADER_LENGTH: usize = 14;
 const ETHERNET_HEADER_OFFSET: usize = 34;
 const IP_PACKET_OFFSET: usize = ETHERNET_HEADER_LENGTH + ETHERNET_HEADER_OFFSET; // - HIF_HEADER_OFFSET;
 
+#[cfg(not(test))]
 pub const SOCKET_BUFFER_MAX_LENGTH: usize = 1400;
+
+#[cfg(test)]
+pub const SOCKET_BUFFER_MAX_LENGTH: usize = 4;
 
 const HIF_SEND_RETRIES: usize = 1000;
 

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -81,11 +81,7 @@ const ETHERNET_HEADER_LENGTH: usize = 14;
 const ETHERNET_HEADER_OFFSET: usize = 34;
 const IP_PACKET_OFFSET: usize = ETHERNET_HEADER_LENGTH + ETHERNET_HEADER_OFFSET; // - HIF_HEADER_OFFSET;
 
-#[cfg(not(test))]
 pub const SOCKET_BUFFER_MAX_LENGTH: usize = 1400;
-
-#[cfg(test)]
-pub const SOCKET_BUFFER_MAX_LENGTH: usize = 4;
 
 const HIF_SEND_RETRIES: usize = 1000;
 


### PR DESCRIPTION
This PR adds the following changes:
1. Added unit tests for the UDP stack, covering the following UDP operations: `Open`, `Connect`, `Send`, `Receive`, `Close`, `Bind`, `SendTo`.
2. Added TCP and UDP stack unit tests to verify that the send function handles packets with a size greater than `MAX_SEND_LENGTH` correctly.
3. Added attributes to set `MAX_SEND_LENGTH` to `4` for test cases to verify large packets for stack send functions.