### PR TITLE
Added test coverage for `sock_holder.rs`

### DIFF
--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -342,7 +342,7 @@ mod test {
 
         client.debug_callback = Some(&mut my_debug);
 
-        // call recieve
+        // call receive
         let result = nb::block!(client.receive(&mut udp_socket, &mut recv_buff));
 
         assert_eq!(result.ok(), Some((test_data.len(), socket_addr)));

--- a/winc-rs/src/stack/sock_holder.rs
+++ b/winc-rs/src/stack/sock_holder.rs
@@ -97,4 +97,29 @@ mod tests {
         assert_eq!(udp_sock.0, 0);
         assert_eq!(udp_sockets.get(udp_sock).unwrap().0.v, 7);
     }
+
+    #[test]
+    fn test_socket_placeholder() {
+        // Verify new socket is created on requested entry
+        let mut socks = SockHolder::<7, 0>::default();
+        let opt_hdl = socks.put(Handle(1), 13);
+
+        assert_eq!(opt_hdl.unwrap().0, 1);
+        assert_eq!(socks.get(Handle(0)), None);
+        assert_eq!(socks.get(Handle(2)), None);
+
+        // Verify socket index is already taken
+        let mut socks = SockHolder::<7, 0>::default();
+        let handle = socks.add(13);
+        let opt_hdl = socks.put(handle.unwrap(), 13);
+
+        assert_eq!(opt_hdl, None);
+
+        // Verify no space is available for new entry
+        let mut socks = SockHolder::<1, 0>::default();
+        let _handle = socks.add(13);
+        let opt_hdl = socks.put(Handle(1), 13);
+
+        assert_eq!(opt_hdl, None);
+    }
 }

--- a/winc-rs/src/stack/sock_holder.rs
+++ b/winc-rs/src/stack/sock_holder.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_socket_placeholder() {
-        // Verify new socket is created on requested entry
+        // Verify a new socket is created for the requested entry
         let mut socks = SockHolder::<7, 0>::default();
         let opt_hdl = socks.put(Handle(1), 13);
 
@@ -108,14 +108,14 @@ mod tests {
         assert_eq!(socks.get(Handle(0)), None);
         assert_eq!(socks.get(Handle(2)), None);
 
-        // Verify socket index is already taken
+        // Verify if the socket index is already taken
         let mut socks = SockHolder::<7, 0>::default();
         let handle = socks.add(13);
         let opt_hdl = socks.put(handle.unwrap(), 13);
 
         assert_eq!(opt_hdl, None);
 
-        // Verify no space is available for new entry
+        // Verify no space is available for new entries
         let mut socks = SockHolder::<1, 0>::default();
         let _handle = socks.add(13);
         let opt_hdl = socks.put(Handle(1), 13);

--- a/winc-rs/src/stack/sock_holder.rs
+++ b/winc-rs/src/stack/sock_holder.rs
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_socket_placeholder() {
+    fn test_socket_check_new_entry() {
         // Verify a new socket is created for the requested entry
         let mut socks = SockHolder::<7, 0>::default();
         let opt_hdl = socks.put(Handle(1), 13);
@@ -107,14 +107,20 @@ mod tests {
         assert_eq!(opt_hdl.unwrap().0, 1);
         assert_eq!(socks.get(Handle(0)), None);
         assert_eq!(socks.get(Handle(2)), None);
+    }
 
+    #[test]
+    fn test_socket_index_is_taken() {
         // Verify if the socket index is already taken
         let mut socks = SockHolder::<7, 0>::default();
         let handle = socks.add(13);
         let opt_hdl = socks.put(handle.unwrap(), 13);
 
         assert_eq!(opt_hdl, None);
+    }
 
+    #[test]
+    fn test_socket_no_space_for_new_entries() {
         // Verify no space is available for new entries
         let mut socks = SockHolder::<1, 0>::default();
         let _handle = socks.add(13);


### PR DESCRIPTION
This PR adds the missing unit test cases for the functions in `sock_holder.rs` and improves the overall test coverage of the `stack` module.