### PR TITLE
Added support for disconnect command

### DIFF
--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -23,7 +23,7 @@ impl<X: Xfer> AsyncClient<'_, X> {
                 .boot_the_chip(&mut state)
                 .map_err(StackError::WincWifiFail)?;
             if result {
-                self.callbacks.borrow_mut().state = WifiModuleState::Started;
+                self.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
                 return Ok(());
             }
             self.dispatch_events()?;

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -741,6 +741,16 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    pub fn send_disconnect(&mut self) -> Result<(), Error> {
+        self.write_hif_header(
+            HifGroup::Wifi(WifiResponse::Unhandled),
+            WifiRequest::Disconnect,
+            &[],
+            false,
+        )?;
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
     pub fn dispatch_events_new<T: EventListener>(&mut self, listener: &mut T) -> Result<(), Error> {
         let res = self.is_interrupt_pending()?;
         if !res.0 {

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -24,12 +24,11 @@ pub struct Handle(pub u8);
 pub(crate) enum WifiModuleState {
     Reset,
     Starting,
-    Started,
+    Unconnected,
     ConnectingToAp,
     ConnectedToAp,
     ConnectionFailed,
     Disconnecting,
-    Disconnected,
 }
 
 /// Ping operation results
@@ -265,8 +264,12 @@ impl EventListener for SocketCallbacks {
             WifiConnState::Disconnected => {
                 if self.state == WifiModuleState::ConnectingToAp {
                     self.state = WifiModuleState::ConnectionFailed;
+                    debug!(
+                        "on_connstate_changed FAILED: {:?} {:?}",
+                        self.connection_state.conn_state, self.connection_state.conn_error
+                    );
                 } else {
-                    self.state = WifiModuleState::Disconnected;
+                    self.state = WifiModuleState::Unconnected;
                 }
             }
             _ => {

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -28,6 +28,8 @@ pub(crate) enum WifiModuleState {
     ConnectingToAp,
     ConnectedToAp,
     ConnectionFailed,
+    Disconnecting,
+    Disconnected,
 }
 
 /// Ping operation results
@@ -255,19 +257,18 @@ impl EventListener for SocketCallbacks {
         debug!("client: Connection state changed: {:?} {:?}", state, err);
         self.connection_state.conn_state = state;
         self.connection_state.conn_error = Some(err);
-        match self.state {
-            WifiModuleState::ConnectingToAp => match self.connection_state.conn_state {
-                WifiConnState::Connected => {
-                    self.state = WifiModuleState::ConnectedToAp;
-                }
-                _ => {
+
+        match self.connection_state.conn_state {
+            WifiConnState::Connected => {
+                self.state = WifiModuleState::ConnectedToAp;
+            }
+            WifiConnState::Disconnected => {
+                if self.state == WifiModuleState::ConnectingToAp {
                     self.state = WifiModuleState::ConnectionFailed;
-                    debug!(
-                        "on_connstate_changed FAILED: {:?} {:?}",
-                        self.connection_state.conn_state, self.connection_state.conn_error
-                    );
+                } else {
+                    self.state = WifiModuleState::Disconnected;
                 }
-            },
+            }
             _ => {
                 error!(
                     "UNKNOWN STATE on_connstate_changed: {:?} {:?}",


### PR DESCRIPTION
This PR adds the following changes:
1. Added logic to send the disconnect request and handle its response.
2. Introduced new states, `Disconnecting` and `Disconnected`, in the `WifiModuleState` enum for handling the disconnect command's request and response.
3. Updated the `on_connstate_changed` callback function to accommodate the disconnect response.
4. Updated the `connect_to_ap_impl` function to handle the module's disconnected state.
5. Added unit test cases for the disconnect command.
