### PR TITLE
Support for provisioning mode.

### DIFF
--- a/feather/Cargo.toml
+++ b/feather/Cargo.toml
@@ -26,6 +26,7 @@ embedded-nal = "=0.9.0"
 wincwifi = { path = "../winc-rs", default-features = false, features=["defmt"] }
 demos = { path = "../demos", default-features = false, features=["defmt"] }
 ssd1306 = { version = "0.10", optional = true }
+arrayvec =  { version = "0.7.2", default-features = false, optional = true}
 
 [[example]]
 name = "iperf3_client"

--- a/feather/Cargo.toml
+++ b/feather/Cargo.toml
@@ -26,7 +26,6 @@ embedded-nal = "=0.9.0"
 wincwifi = { path = "../winc-rs", default-features = false, features=["defmt"] }
 demos = { path = "../demos", default-features = false, features=["defmt"] }
 ssd1306 = { version = "0.10", optional = true }
-arrayvec =  { version = "0.7.2", default-features = false, optional = true}
 
 [[example]]
 name = "iperf3_client"

--- a/feather/examples/provisioning.rs
+++ b/feather/examples/provisioning.rs
@@ -1,0 +1,83 @@
+//! Provisioning Mode
+//!
+
+#![no_main]
+#![no_std]
+
+use feather as bsp;
+use feather::init::init;
+
+use bsp::shared::SpiStream;
+use feather::hal::ehal::digital::OutputPin;
+use feather::shared::{create_countdowns, delay_fn};
+use wincwifi::{AccessPoint, StackError, WincClient};
+
+fn program() -> Result<(), StackError> {
+    if let Ok(mut ini) = init() {
+        defmt::println!("Hello, Winc PRNG");
+        let red_led = &mut ini.red_led;
+
+        let mut cnt = create_countdowns(&ini.delay_tick);
+        let mut delay_ms = delay_fn(&mut cnt.0);
+
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
+
+        let mut v = 0;
+        loop {
+            match stack.start_wifi_module() {
+                Ok(_) => break,
+                Err(nb::Error::WouldBlock) => {
+                    defmt::debug!("Waiting start .. {}", v);
+                    v += 1;
+                    delay_ms(5)
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        // Configure the access point with WPA/WPA2 security using the provided SSID and password.
+        let access_point = AccessPoint::wpa("test_winc_rs", "test1234556");
+        // Start the provising mode.
+        stack.start_provisioning_mode(access_point, "winctest", true)?;
+        defmt::println!("Provisioning Started for 15 minutes");
+        // Check for provisioning information is receieved for 15 minutes.
+        let result = nb::block!(stack.get_provisioning_info(15));
+        match result {
+            Ok(info) => {
+                defmt::info!("Credentials received from provisioning; connecting to access point.");
+                // Connect to access point.
+                nb::block!(stack.connect_to_ap(&info.ssid, &info.passphrase, false))?;
+                defmt::info!("Connected to AP");
+            }
+            Err(err) => {
+                if err == StackError::GeneralTimeout {
+                    defmt::error!(
+                        "No information was received for 15 minutes. Stopping provisioning mode."
+                    );
+                    stack.stop_provisioning_mode()?;
+                } else {
+                    defmt::error!("Provisioning Failed");
+                }
+            }
+        }
+
+        loop {
+            delay_ms(200);
+            red_led.set_high().unwrap();
+            delay_ms(200);
+            red_led.set_low().unwrap();
+            stack.heartbeat().unwrap();
+        }
+    }
+    Ok(())
+}
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    if let Err(err) = program() {
+        defmt::error!("Error: {}", err);
+        panic!("Error in main program");
+    } else {
+        defmt::info!("Good exit")
+    };
+    loop {}
+}

--- a/winc-rs/Cargo.toml
+++ b/winc-rs/Cargo.toml
@@ -57,6 +57,7 @@ embedded-nal-async = ["dep:embedded-nal-async"]
 async = ["dep:embedded-nal-async"]
 rng = ["dep:rand_core"]
 large_rng = [] # This will allocate a 1.6KB buffer for the PRNG upon initialization.
+enable-wep = []
 
 # Todo: add feature flags to save binary space
 # - TCP

--- a/winc-rs/Cargo.toml
+++ b/winc-rs/Cargo.toml
@@ -57,7 +57,7 @@ embedded-nal-async = ["dep:embedded-nal-async"]
 async = ["dep:embedded-nal-async"]
 rng = ["dep:rand_core"]
 large_rng = [] # This will allocate a 1.6KB buffer for the PRNG upon initialization.
-wep = []
+wep = [] # This will enable weak WEP network security.
 
 # Todo: add feature flags to save binary space
 # - TCP

--- a/winc-rs/Cargo.toml
+++ b/winc-rs/Cargo.toml
@@ -57,7 +57,7 @@ embedded-nal-async = ["dep:embedded-nal-async"]
 async = ["dep:embedded-nal-async"]
 rng = ["dep:rand_core"]
 large_rng = [] # This will allocate a 1.6KB buffer for the PRNG upon initialization.
-enable-wep = []
+wep = []
 
 # Todo: add feature flags to save binary space
 # - TCP

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -2,8 +2,9 @@ use crate::errors::Error;
 
 use embedded_nal::nb;
 
+use crate::error;
 use crate::manager::{AccessPoint, AuthType, FirmwareInfo, IPConf, ScanResult};
-use crate::manager::{Credentials, HostName, ProvisionalInfo};
+use crate::manager::{Credentials, HostName, ProvisioningInfo};
 
 use super::PingResult;
 use super::StackError;
@@ -18,6 +19,11 @@ use crate::info;
 const AP_CONNECT_TIMEOUT_MILLISECONDS: u32 = 60_000;
 // 5 seconds max, assuming no additional delays
 const AP_DISCONNECT_TIMEOUT_MILLISECONDS: u32 = 5_000;
+// Timeout for Provisioning
+#[cfg(not(test))]
+const PROVISIONING_TIMEOUT: u32 = 60 * 1000;
+#[cfg(test)]
+const PROVISIONING_TIMEOUT: u32 = 1000;
 
 impl<X: Xfer> WincClient<'_, X> {
     /// Call this periodically to receive network events
@@ -71,10 +77,7 @@ impl<X: Xfer> WincClient<'_, X> {
         connect_fn: impl FnOnce(&mut Self) -> Result<(), crate::errors::Error>,
     ) -> nb::Result<(), StackError> {
         match self.callbacks.state {
-            WifiModuleState::Reset
-            | WifiModuleState::Starting
-            | WifiModuleState::Disconnecting
-            | WifiModuleState::ProvisioningFailed => {
+            WifiModuleState::Reset | WifiModuleState::Starting | WifiModuleState::Disconnecting => {
                 Err(nb::Error::Other(StackError::InvalidState))
             }
             WifiModuleState::Unconnected | WifiModuleState::Provisioning => {
@@ -332,49 +335,69 @@ impl<X: Xfer> WincClient<'_, X> {
         }
     }
 
-    /// Starts provisioning mode. This command is only applicable when the chip is in station mode.
+    /// Starts the provisioning mode. This command is only applicable when the chip is in station mode.
     ///
     /// # Arguments
     ///
     /// * `ap` - An `AccessPoint` struct containing the SSID, password, and other network details.
     /// * `hostname` - Device domain name. Must not include `.local`.
     /// * `http_redirect` - Whether HTTP redirection is enabled.
+    /// * `timeout` - The timeout duration for provisioning, in minutes.
     ///
     /// # Returns
     ///
-    /// * `()` - If provisioning mode starts successfully.
-    /// * `StackError` - If an error occurs while starting provisioning mode.
-    pub fn start_provisioning_mode(
+    /// * `ProvisioningInfo` - Wifi Credentials received from provisioning.
+    /// * `StackError` - If an error occurs while starting provisioning mode or receiving provisioning information.
+    pub fn provisioning_mode(
         &mut self,
         ap: &AccessPoint,
         hostname: &HostName,
         http_redirect: bool,
-    ) -> Result<(), StackError> {
+        timeout: u32,
+    ) -> nb::Result<ProvisioningInfo, StackError> {
         match &mut self.callbacks.state {
             WifiModuleState::Unconnected | WifiModuleState::ConnectedToAp => {
                 let auth = <Credentials as Into<AuthType>>::into(ap.key);
 
                 if auth == AuthType::S802_1X {
-                    unimplemented!("Enterprise Security in provisioning mode is not supported");
-                }
-
-                #[cfg(not(feature = "wep"))]
-                if auth == AuthType::WEP {
-                    unimplemented!("WEP provides very weak security and is disabled by default.");
+                    error!("Enterprise Security in provisioning mode is not supported");
+                    return Err(nb::Error::Other(StackError::InvalidParameters));
                 }
 
                 self.manager
                     .send_start_provisioning(ap, hostname, http_redirect)
-                    .map_err(StackError::WincWifiFail)?;
+                    .map_err(|x| nb::Error::Other(StackError::WincWifiFail(x)))?;
 
                 self.callbacks.state = WifiModuleState::Provisioning;
+                self.callbacks.provisioning_info = None;
             }
+            WifiModuleState::Provisioning => match &mut self.callbacks.provisioning_info {
+                None => {
+                    self.operation_countdown = timeout * PROVISIONING_TIMEOUT;
+                    self.callbacks.provisioning_info = Some(None);
+                }
+                Some(result) => {
+                    if let Some(info) = result.take() {
+                        if info.status {
+                            return Ok(info);
+                        }
+                        return Err(nb::Error::Other(StackError::WincWifiFail(Error::Failed)));
+                    } else {
+                        self.delay_us(self.poll_loop_delay_us);
+                        self.operation_countdown -= 1;
+                        if self.operation_countdown == 0 {
+                            return Err(nb::Error::Other(StackError::GeneralTimeout));
+                        }
+                    }
+                }
+            },
             _ => {
-                return Err(StackError::InvalidState);
+                return Err(nb::Error::Other(StackError::InvalidState));
             }
         }
 
-        Ok(())
+        self.dispatch_events()?;
+        Err(nb::Error::WouldBlock)
     }
 
     /// Stops provisioning mode. This command is only applicable when the chip is in provisioning mode.
@@ -382,7 +405,7 @@ impl<X: Xfer> WincClient<'_, X> {
     /// # Returns
     ///
     /// * `()` - If provisioning mode starts successfully.
-    /// * `StackError` - If an error occurs while starting provisioning mode.
+    /// * `StackError` - If an error occurs while stopping provisioning mode.
     pub fn stop_provisioning_mode(&mut self) -> Result<(), StackError> {
         if self.callbacks.state == WifiModuleState::Provisioning {
             self.manager
@@ -396,53 +419,6 @@ impl<X: Xfer> WincClient<'_, X> {
         self.callbacks.state = WifiModuleState::Unconnected;
         Ok(())
     }
-
-    /// Get the provisioning information.
-    ///
-    /// # Arguments
-    ///
-    /// * `timeout` - The timeout duration for provisioning, in minutes.
-    ///
-    /// # Returns
-    ///
-    /// * `ProvisionalInfo` - Wifi Credentials received from provisioning.
-    /// * `StackError` - If an error occurs while receiving provisioning information.
-    pub fn get_provisioning_info(
-        &mut self,
-        timeout: u32,
-    ) -> nb::Result<ProvisionalInfo, StackError> {
-        match self.callbacks.state {
-            WifiModuleState::Provisioning => {
-                match &mut self.callbacks.provisioning_info {
-                    None => {
-                        self.operation_countdown = timeout * 60 * 1000; // passing in miliseconds
-                        self.callbacks.provisioning_info = Some(None);
-                        Err(nb::Error::WouldBlock)
-                    }
-                    Some(result) => {
-                        if let Some(info) = result.take() {
-                            Ok(info)
-                        } else {
-                            self.delay_us(self.poll_loop_delay_us);
-                            self.dispatch_events()?;
-                            self.operation_countdown -= 1;
-                            if self.operation_countdown == 0 {
-                                return Err(nb::Error::Other(StackError::GeneralTimeout));
-                            }
-                            Err(nb::Error::WouldBlock)
-                        }
-                    }
-                }
-            }
-            WifiModuleState::ProvisioningFailed => {
-                Err(nb::Error::Other(StackError::WincWifiFail(Error::Failed)))
-            }
-            _ => {
-                info!("State of Wifi module: {:?}", self.callbacks.state);
-                Err(nb::Error::Other(StackError::InvalidState))
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -455,7 +431,9 @@ mod tests {
     use crate::errors::Error;
     use crate::manager::Ssid;
     use crate::manager::{EventListener, PingError, WifiConnError, WifiConnState};
-    use crate::ConnectionInfo;
+    use crate::{ConnectionInfo, Credentials, S8Password, S8Username, WifiChannel, WpaKey};
+    #[cfg(feature = "wep")]
+    use crate::{WepKey, WepKeyIndex};
 
     #[test]
     fn test_heartbeat() {
@@ -646,5 +624,261 @@ mod tests {
         let result = nb::block!(client.disconnect_ap());
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_provisioning_mode_open_success() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        // Should be empty for Open network.
+        let test_key = WpaKey::new();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::Open, true);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::Open);
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_provisioning_mode_wpa_success() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // wpa key for access point configuration.
+        let ap_key = WpaKey::from("wpa_key").unwrap();
+        // Access Point Configuration.
+        let ap = AccessPoint::wpa(&ap_ssid, &ap_key);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        let test_key = WpaKey::from("test_key").unwrap();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::WpaPSK, true);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::WpaPSK(test_key));
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[cfg(feature = "wep")]
+    #[test]
+    fn test_provisioning_mode_wep_success() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // wep key for access point configuration.
+        let ap_key = WepKey::from("wep_key").unwrap();
+        // Wep key index
+        let wep_key_index = WepKeyIndex::Key1;
+        // Access Point Configuration.
+        let ap = AccessPoint::wep(&ap_ssid, &ap_key, wep_key_index);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        let test_key = WpaKey::from("test_wep_key").unwrap();
+        // Wep Key received from provisioning.
+        let test_wep_key = WepKey::from("test_wep_key").unwrap();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::WEP, true);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::Wep(test_wep_key, wep_key_index));
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_provisioning_mode_enterprise_fail() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // S802_1X Username for network credentials.
+        let s8_username = S8Username::from("username").unwrap();
+        // S802_1X Password for network credentials.
+        let s8_password = S8Password::from("password").unwrap();
+        // S802_1X network credentials.
+        let ap_key = Credentials::S802_1X(s8_username, s8_password);
+
+        // Access Point Configuration.
+        let ap = AccessPoint {
+            ssid: &ap_ssid,
+            key: ap_key,
+            channel: WifiChannel::Channel1,
+            ssid_hidden: false,
+            ip: Ipv4Addr::new(192, 168, 1, 1),
+        };
+
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error, StackError::InvalidParameters);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_provisioning_invalid_state() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::ConnectingToAp;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert_eq!(err, StackError::InvalidState);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_provisioning_timeout() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1500)); // Time is in miliseconds
+
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert_eq!(err, StackError::GeneralTimeout);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_provisioning_failed() {
+        // test client
+        let mut client = make_test_client();
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        // Should be empty for Open network.
+        let test_key = WpaKey::new();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::Open, false);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error, StackError::WincWifiFail(Error::Failed));
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    fn test_stop_provisioning_success() {
+        // test client
+        let mut client = make_test_client();
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Provisioning;
+
+        let result = client.stop_provisioning_mode();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_stop_provisioning_state_error() {
+        // test client
+        let mut client = make_test_client();
+        // set the module state to unconnected.
+        client.callbacks.state = WifiModuleState::Unconnected;
+
+        let result = client.stop_provisioning_mode();
+
+        assert!(result.is_err());
     }
 }

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -346,22 +346,22 @@ impl<X: Xfer> WincClient<'_, X> {
     /// * `StackError` - If an error occurs while starting provisioning mode.
     pub fn start_provisioning_mode(
         &mut self,
-        ap: AccessPoint,
+        ap: &AccessPoint,
         dns: &str,
         http_redirect: bool,
     ) -> Result<(), StackError> {
         match &mut self.callbacks.state {
             WifiModuleState::Unconnected | WifiModuleState::ConnectedToAp => {
-                if ap.auth == AuthType::Invalid {
+                if ap.credentials.auth == AuthType::Invalid {
                     return Err(StackError::Unexpected);
                 }
 
-                if ap.auth == AuthType::S802_1X {
+                if ap.credentials.auth == AuthType::S802_1X {
                     unimplemented!("Enterprise Security is not yet supported");
                 }
 
-                #[cfg(not(feature = "enable-wep"))]
-                if ap.auth == AuthType::WEP {
+                #[cfg(not(feature = "wep"))]
+                if ap.credentials.auth == AuthType::WEP {
                     unimplemented!("WEP provides very weak security and is disabled by default.");
                 }
 

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -74,6 +74,7 @@ pub use transfer::Xfer as Transfer;
 pub use client::PingResult;
 pub use client::StackError;
 pub use client::WincClient;
+pub use manager::AccessPoint;
 pub use manager::AuthType;
 pub use manager::ConnectionInfo;
 pub use manager::FirmwareInfo;

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -74,10 +74,12 @@ pub use transfer::Xfer as Transfer;
 pub use client::PingResult;
 pub use client::StackError;
 pub use client::WincClient;
-pub use manager::AccessPoint;
 pub use manager::AuthType;
 pub use manager::ConnectionInfo;
 pub use manager::FirmwareInfo;
+#[cfg(feature = "wep")]
+pub use manager::WepKey;
+pub use manager::{AccessPoint, Credentials, HostName, Ssid, WpaKey};
 
 // TODO: maybe don't expose this directly
 pub use manager::ScanResult;

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -77,9 +77,11 @@ pub use client::WincClient;
 pub use manager::AuthType;
 pub use manager::ConnectionInfo;
 pub use manager::FirmwareInfo;
+pub use manager::{
+    AccessPoint, Credentials, HostName, S8Password, S8Username, Ssid, WifiChannel, WpaKey,
+};
 #[cfg(feature = "wep")]
-pub use manager::WepKey;
-pub use manager::{AccessPoint, Credentials, HostName, Ssid, WpaKey};
+pub use manager::{WepKey, WepKeyIndex};
 
 // TODO: maybe don't expose this directly
 pub use manager::ScanResult;

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -27,14 +27,15 @@ mod responses;
 use crate::{debug, trace};
 
 use chip_access::ChipAccess;
-pub use constants::WifiConnError;
 #[cfg(feature = "wep")]
-pub(crate) use constants::DEFAULT_WEP_KEY_INDEX;
-pub use constants::{AuthType, PingError, SocketError, WifiConnState}; // todo response shouldn't be leaking
+pub use constants::WepKeyIndex;
+pub use constants::{AuthType, PingError, SocketError, WifiChannel, WifiConnError, WifiConnState}; // todo response shouldn't be leaking
 use constants::{IpCode, Regs, WifiResponse};
 use constants::{WifiRequest, PROVISIONING_INFO_PACKET_SIZE};
 
-pub use net_types::{AccessPoint, Credentials, HostName, ProvisionalInfo, Ssid, WpaKey};
+pub use net_types::{
+    AccessPoint, Credentials, HostName, ProvisioningInfo, S8Password, S8Username, Ssid, WpaKey,
+};
 
 #[cfg(feature = "wep")]
 pub use net_types::WepKey;

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -27,9 +27,7 @@ mod responses;
 use crate::{debug, trace};
 use chip_access::ChipAccess;
 pub use constants::WifiConnError;
-pub use constants::{
-    AuthType, PingError, SocketError, WifiConnState, MAX_PSK_KEY_LEN, MAX_SSID_LEN,
-}; // todo response shouldn't be leaking
+pub use constants::{AuthType, PingError, SocketError, WifiConnState}; // todo response shouldn't be leaking
 use constants::{IpCode, Regs, WifiResponse};
 use constants::{WifiRequest, PROVISIONING_INFO_PACKET_SIZE};
 pub use net_types::{AccessPoint, WifiCredentials};
@@ -139,7 +137,7 @@ pub trait EventListener {
     fn on_recv(&mut self, socket: Socket, address: SocketAddrV4, data: &[u8], err: SocketError);
     fn on_recvfrom(&mut self, socket: Socket, address: SocketAddrV4, data: &[u8], err: SocketError);
     fn on_prng(&mut self, data: &[u8]);
-    fn on_provisioning(&mut self, ssid: &str, passphrase: &str, security: AuthType, status: bool);
+    fn on_provisioning(&mut self, ssid: &[u8], passphrase: &[u8], security: AuthType, status: bool);
 }
 
 pub struct Manager<X: Xfer> {
@@ -810,7 +808,7 @@ impl<X: Xfer> Manager<X> {
     /// * `Error` - If an error occurs during packet preparation or sending.
     pub fn send_start_provisioning(
         &mut self,
-        ap: AccessPoint,
+        ap: &AccessPoint,
         dns: &str,
         http_redirect: bool,
     ) -> Result<(), Error> {

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -21,18 +21,21 @@ use crate::transfer::Xfer;
 
 mod chip_access;
 mod constants;
+mod net_types;
 mod requests;
 mod responses;
 use crate::{debug, trace};
 use chip_access::ChipAccess;
-use constants::WifiRequest;
-pub use constants::{AuthType, PingError, SocketError, WifiConnState}; // todo response shouldn't be leaking
+pub use constants::WifiConnError;
+pub use constants::{
+    AuthType, PingError, SocketError, WifiConnState, MAX_PSK_KEY_LEN, MAX_SSID_LEN,
+}; // todo response shouldn't be leaking
 use constants::{IpCode, Regs, WifiResponse};
+use constants::{WifiRequest, PROVISIONING_INFO_PACKET_SIZE};
+pub use net_types::{AccessPoint, WifiCredentials};
 use requests::*;
 pub use responses::IPConf;
 use responses::*;
-
-pub use constants::WifiConnError;
 pub use responses::{ConnectionInfo, ScanResult};
 
 use core::net::{Ipv4Addr, SocketAddrV4};
@@ -136,6 +139,7 @@ pub trait EventListener {
     fn on_recv(&mut self, socket: Socket, address: SocketAddrV4, data: &[u8], err: SocketError);
     fn on_recvfrom(&mut self, socket: Socket, address: SocketAddrV4, data: &[u8], err: SocketError);
     fn on_prng(&mut self, data: &[u8]);
+    fn on_provisioning(&mut self, ssid: &str, passphrase: &str, security: AuthType, status: bool);
 }
 
 pub struct Manager<X: Xfer> {
@@ -790,6 +794,54 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a request to start provisioning mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `ap` - Configuration parameters for the access point, including SSID, password, authentication type, etc.
+    /// * `dns` - DNS redirect URL as a string slice. Must not end with `.local`.
+    /// * `http_redirect` - Enables or disables HTTP redirection. If enabled, all HTTP traffic
+    ///   (`http://<URL>`) from devices connected to the WINC access point will be redirected
+    ///   to the HTTP provisioning web page.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs during packet preparation or sending.
+    pub fn send_start_provisioning(
+        &mut self,
+        ap: AccessPoint,
+        dns: &str,
+        http_redirect: bool,
+    ) -> Result<(), Error> {
+        let req = write_start_provisioning_req(ap, dns, http_redirect)?;
+        self.write_hif_header(
+            HifGroup::Wifi(WifiResponse::Unhandled),
+            WifiRequest::StartProvisionMode,
+            &req,
+            true,
+        )?;
+        self.chip
+            .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
+    /// Sends a request to stop provisioning mode.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs during packet preparation or transmission.
+    pub fn send_stop_provisioning(&mut self) -> Result<(), Error> {
+        self.write_hif_header(
+            HifGroup::Wifi(WifiResponse::Unhandled),
+            WifiRequest::StopProvisionMode,
+            &[],
+            false,
+        )?;
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
     pub fn dispatch_events_new<T: EventListener>(&mut self, listener: &mut T) -> Result<(), Error> {
         let res = self.is_interrupt_pending()?;
         if !res.0 {
@@ -858,7 +910,11 @@ impl<X: Xfer> Manager<X> {
                     listener.on_ip_conflict(u32::from_be_bytes(result).into());
                 }
                 WifiResponse::ProvisionInfo => {
-                    unimplemented!("Provisioning not yet supported")
+                    let mut response = [0u8; PROVISIONING_INFO_PACKET_SIZE];
+                    // read the provisioning info
+                    self.read_block(address, &mut response)?;
+                    let res = read_provisioning_reply(&response)?;
+                    listener.on_provisioning(&res.0, &res.1, (res.2).into(), res.3);
                 }
                 WifiResponse::GetPrng => {
                     let mut response = [0; PRNG_DATA_LENGTH];

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -12,6 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Maxmimum length of SSID.
+pub const MAX_SSID_LEN: usize = 32;
+/// Length for 104 bit string passpharase.
+pub(crate) const MAX_WEP_KEY_LEN: usize = 26;
+#[cfg(feature = "enable-wep")]
+/// Length for 40 bit string passpharase.
+pub(crate) const MIN_WEP_KEY_LEN: usize = 10;
+/// Maximum length for the WPA PSK Key.
+pub const MAX_PSK_KEY_LEN: usize = 64;
+// Minimum length of the WPA PSK Key.
+pub(crate) const MIN_PSK_KEY_LEN: usize = 8;
+/// Maximum length for dns server url for provisioning mode.
+pub const MAX_DNS_URL_LEN: usize = 64;
+/// Maximum WiFi Channels supported
+pub(crate) const MAX_WIFI_CHANNEL: usize = 14;
+/// Minimum WiFi Channels supported
+pub(crate) const MIN_WIFI_CHANNEL: usize = 1;
+/// Packet size of the Start Provisioning Mode request.
+pub(crate) const START_PROVISION_PACKET_SIZE: usize = 204;
+/// Packet size of Provisioning Info.
+pub(crate) const PROVISIONING_INFO_PACKET_SIZE: usize = 100;
+
 pub enum Regs {
     SpiConfig = 0xE824,
     ChipId = 0x1000,
@@ -70,7 +92,7 @@ impl core::fmt::Display for WifiConnError {
 
 /// Type of authentication used by an access point
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, Clone, Copy)]
 pub enum AuthType {
     #[default]
     Invalid,

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -16,19 +16,15 @@
 pub const MAX_SSID_LEN: usize = 32;
 /// Length for 104 bit string passpharase.
 pub(crate) const MAX_WEP_KEY_LEN: usize = 26;
-#[cfg(feature = "enable-wep")]
+#[cfg(feature = "wep")]
 /// Length for 40 bit string passpharase.
 pub(crate) const MIN_WEP_KEY_LEN: usize = 10;
 /// Maximum length for the WPA PSK Key.
-pub const MAX_PSK_KEY_LEN: usize = 64;
+pub const MAX_PSK_KEY_LEN: usize = 63;
 // Minimum length of the WPA PSK Key.
 pub(crate) const MIN_PSK_KEY_LEN: usize = 8;
 /// Maximum length for dns server url for provisioning mode.
-pub const MAX_DNS_URL_LEN: usize = 64;
-/// Maximum WiFi Channels supported
-pub(crate) const MAX_WIFI_CHANNEL: usize = 14;
-/// Minimum WiFi Channels supported
-pub(crate) const MIN_WIFI_CHANNEL: usize = 1;
+pub const MAX_DNS_URL_LEN: usize = 63;
 /// Packet size of the Start Provisioning Mode request.
 pub(crate) const START_PROVISION_PACKET_SIZE: usize = 204;
 /// Packet size of Provisioning Info.
@@ -384,5 +380,54 @@ impl From<u8> for SocketError {
             242 => Self::BufferFull,
             _ => Self::Unhandled,
         }
+    }
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WifiChannel {
+    Channel1 = 1, // Default Value
+    Channel2 = 2,
+    Channel3 = 3,
+    Channel4 = 4,
+    Channel5 = 5,
+    Channel6 = 6,
+    Channel7 = 7,
+    Channel8 = 8,
+    Channel9 = 9,
+    Channel10 = 10,
+    Channel11 = 11,
+    Channel12 = 12,
+    Channel13 = 13,
+    Channel14 = 14,
+    ChannelAll = 255,
+}
+
+impl From<u8> for WifiChannel {
+    fn from(n: u8) -> Self {
+        match n {
+            1 => WifiChannel::Channel1,
+            2 => WifiChannel::Channel2,
+            3 => WifiChannel::Channel3,
+            4 => WifiChannel::Channel4,
+            5 => WifiChannel::Channel5,
+            6 => WifiChannel::Channel6,
+            7 => WifiChannel::Channel7,
+            8 => WifiChannel::Channel8,
+            9 => WifiChannel::Channel9,
+            10 => WifiChannel::Channel10,
+            11 => WifiChannel::Channel11,
+            12 => WifiChannel::Channel12,
+            13 => WifiChannel::Channel13,
+            14 => WifiChannel::Channel14,
+            255 => WifiChannel::ChannelAll,
+            _ => WifiChannel::Channel1, // Default Value
+        }
+    }
+}
+
+impl From<WifiChannel> for u8 {
+    fn from(val: WifiChannel) -> Self {
+        val as Self
     }
 }

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -432,6 +432,7 @@ impl From<WifiChannel> for u8 {
     }
 }
 
+/// Wep Key Index
 #[cfg(feature = "wep")]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -26,11 +26,8 @@ pub(crate) const START_PROVISION_PACKET_SIZE: usize = 204;
 pub(crate) const PROVISIONING_INFO_PACKET_SIZE: usize = 100;
 /// Maximum password length for the enterprise mode.
 pub const MAX_S802_PASSWORD_LEN: usize = 40;
-/// Maximum usuername length for the Enterprise mode.
+/// Maximum username length for the Enterprise mode.
 pub const MAX_S802_USERNAME_LEN: usize = 20;
-#[cfg(feature = "wep")]
-/// Default Wep Key index.
-pub(crate) const DEFAULT_WEP_KEY_INDEX: usize = 1;
 
 pub enum Regs {
     SpiConfig = 0xE824,
@@ -432,5 +429,37 @@ impl From<u8> for WifiChannel {
 impl From<WifiChannel> for u8 {
     fn from(val: WifiChannel) -> Self {
         val as Self
+    }
+}
+
+#[cfg(feature = "wep")]
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WepKeyIndex {
+    NoKey = 0,
+    Key1 = 1,
+    Key2 = 2,
+    Key3 = 3,
+    Key4 = 4,
+}
+
+#[cfg(feature = "wep")]
+impl From<WepKeyIndex> for u8 {
+    fn from(val: WepKeyIndex) -> Self {
+        val as Self
+    }
+}
+
+#[cfg(feature = "wep")]
+impl From<u8> for WepKeyIndex {
+    fn from(n: u8) -> Self {
+        match n {
+            0 => WepKeyIndex::NoKey,
+            1 => WepKeyIndex::Key1,
+            2 => WepKeyIndex::Key2,
+            3 => WepKeyIndex::Key3,
+            4 => WepKeyIndex::Key4,
+            _ => WepKeyIndex::NoKey, // Default Value
+        }
     }
 }

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -16,19 +16,21 @@
 pub const MAX_SSID_LEN: usize = 32;
 /// Length for 104 bit string passpharase.
 pub(crate) const MAX_WEP_KEY_LEN: usize = 26;
-#[cfg(feature = "wep")]
-/// Length for 40 bit string passpharase.
-pub(crate) const MIN_WEP_KEY_LEN: usize = 10;
 /// Maximum length for the WPA PSK Key.
 pub const MAX_PSK_KEY_LEN: usize = 63;
-// Minimum length of the WPA PSK Key.
-pub(crate) const MIN_PSK_KEY_LEN: usize = 8;
-/// Maximum length for dns server url for provisioning mode.
-pub const MAX_DNS_URL_LEN: usize = 63;
+/// Maximum length for Device domain name for provisioning mode.
+pub const MAX_HOST_NAME_LEN: usize = 63;
 /// Packet size of the Start Provisioning Mode request.
 pub(crate) const START_PROVISION_PACKET_SIZE: usize = 204;
 /// Packet size of Provisioning Info.
 pub(crate) const PROVISIONING_INFO_PACKET_SIZE: usize = 100;
+/// Maximum password length for the enterprise mode.
+pub const MAX_S802_PASSWORD_LEN: usize = 40;
+/// Maximum usuername length for the Enterprise mode.
+pub const MAX_S802_USERNAME_LEN: usize = 20;
+#[cfg(feature = "wep")]
+/// Default Wep Key index.
+pub(crate) const DEFAULT_WEP_KEY_INDEX: usize = 1;
 
 pub enum Regs {
     SpiConfig = 0xE824,
@@ -383,6 +385,7 @@ impl From<u8> for SocketError {
     }
 }
 
+// Wi-Fi RF Channels
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WifiChannel {

--- a/winc-rs/src/manager/net_types.rs
+++ b/winc-rs/src/manager/net_types.rs
@@ -1,71 +1,329 @@
-use arrayvec::ArrayString;
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-use super::constants::{AuthType, MAX_PSK_KEY_LEN, MAX_SSID_LEN};
+use crate::{errors::Error, StackError};
+
+use super::constants::{AuthType, WifiChannel, MAX_PSK_KEY_LEN, MAX_SSID_LEN, MIN_PSK_KEY_LEN};
 use core::net::Ipv4Addr;
 
-/// Structure for Access Point Configuration.
-pub struct AccessPoint<'a> {
-    /// The SSID (name) of the access point.
-    pub ssid: &'a str,
-    /// The WPA/WPA2 or WEP key for the access point.
-    pub key: &'a str,
-    /// The channel number (1..14) used by the access point.
-    pub channel: u8,
-    /// The authentication type (e.g., WPA, WPA2, WEP)
-    pub auth: AuthType,
-    /// Whether the SSID is hidden (true for hidden).
-    pub ssid_hidden: bool,
-    /// IP address for access point.
-    pub ip: core::net::Ipv4Addr,
-}
+// Default IP address for provisioning mode.
+const PROVISIONING_DEFAULT_IP: u32 = 0xC0A80101;
 
 /// Structure for Wi-Fi Credentials.
 pub struct WifiCredentials {
     /// The SSID (network name) of the network.
-    pub ssid: ArrayString<MAX_SSID_LEN>,
+    pub ssid: [u8; MAX_SSID_LEN],
     /// The passphrase (Wi-Fi key) for the network's security.
-    pub passphrase: ArrayString<MAX_PSK_KEY_LEN>,
+    pub key: [u8; MAX_PSK_KEY_LEN],
     /// The authentication type (e.g., WPA, WPA2, etc.) used by the network.
     pub auth: AuthType,
 }
 
-impl<'a> AccessPoint<'a> {
+/// Structure for Access Point Configuration.
+pub struct AccessPoint {
+    /// Structure for storing Wifi Credentials.
+    pub credentials: WifiCredentials,
+    /// The channel number (1..14) or 255 for all channels used by the access point.
+    pub channel: WifiChannel,
+    /// Whether the SSID is hidden (true for hidden).
+    pub ssid_hidden: bool,
+    /// IP address for the access point. The last octet must be in the range 1 to 100,
+    /// for example: 192.168.1.1 to 192.168.1.100.
+    pub ip: Ipv4Addr,
+}
+
+impl WifiCredentials {
+    /// Checks whether the provided key length is valid for the given authentication type.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth` - The authentication method (e.g., Open, WEP, WPA2).
+    /// * `key_len` - The length of the security key in bytes.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the key length is valid for the specified authentication type.
+    /// * `StackError` - If the key length is invalid.
+    fn check_key_validity(auth: AuthType, key_len: usize) -> Result<(), StackError> {
+        match auth {
+            AuthType::WpaPSK => {
+                if !((MIN_PSK_KEY_LEN..=MAX_PSK_KEY_LEN).contains(&key_len)) {
+                    return Err(StackError::WincWifiFail(Error::BufferError));
+                }
+            }
+            #[cfg(feature = "wep")]
+            AuthType::WEP => {
+                if (key_len != MAX_WEP_KEY_LEN) && (key_len != MIN_WEP_KEY_LEN) {
+                    return Err(StackError::WincWifiFail(Error::BufferError));
+                }
+            }
+            _ => {
+                // do nothing
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Creates new Wi-Fi credentials from the provided parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name) as a UTF-8 string, no more than 32 bytes.
+    /// * `key` - The security key as a UTF-8 string; must meet length requirements based on the `auth` type.
+    /// * `auth` - The authentication method (e.g., Open, WEP, WPA2).
+    ///
+    /// # Notes
+    ///
+    /// For WPA, the security key must be at least 8 bytes (MIN) and no more than 63 bytes long.
+    /// For WEP, the security key should be 10 bytes for 40-bit and 26 bytes for 104-bit.
+    ///
+    /// # Returns
+    ///
+    /// * `WifiCredentials` - The configured Wi-Fi credentials on success.
+    /// * `StackError` - If any parameter fails validation.
+    pub fn new(ssid: &str, key: &str, auth: AuthType) -> Result<Self, StackError> {
+        // SSID
+        let mut _ssid = [0u8; MAX_SSID_LEN];
+        let _ssid_len = ssid.len().min(MAX_SSID_LEN);
+        // Passphrase
+        let mut _key = [0u8; MAX_PSK_KEY_LEN];
+        let _key_len = key.len().min(MAX_PSK_KEY_LEN);
+        // Check the key length validity
+        Self::check_key_validity(auth, key.len())?;
+        // Copy the SSID
+        _ssid[.._ssid_len].copy_from_slice(&(ssid.as_bytes())[.._ssid_len]);
+        // Copy the Passphrase
+        _key[.._key_len].copy_from_slice(&(key.as_bytes()[.._key_len]));
+        Ok(Self {
+            ssid: _ssid,
+            key: _key,
+            auth,
+        })
+    }
+
+    /// Creates new Wi-Fi credentials with open (no security) access.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name) as a UTF-8 string, no more than 32 bytes.
+    ///
+    /// # Returns
+    ///
+    /// * `WifiCredentials` - The configured Wi-Fi credentials without security.
+    /// * `StackError` - If the SSID exceeds the length limit.
+    pub fn open(ssid: &str) -> Result<Self, StackError> {
+        Self::new(ssid, "", AuthType::Open)
+    }
+
+    /// Creates a wifi configuration for a WPA or WPA2-secured access point.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name), up to 32 bytes.
+    /// * `key` - The WPA security key, up to 63 bytes (as per WPA/WPA2 specification).
+    ///
+    /// # Returns
+    ///
+    /// * `WifiCredentials` - The configured Wi-Fi credentials with WPA-PSK security on success.
+    /// * `StackError` - If parameter validation fails.
+    pub fn wpa(ssid: &str, key: &str) -> Result<Self, StackError> {
+        Self::new(ssid, key, AuthType::WpaPSK)
+    }
+
+    #[cfg(feature = "wep")]
+    /// Creates a wifi configuration for a WEP secured access point.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name), up to 32 bytes.
+    /// * `key` - The WEP security key, either 10 bytes (for 40-bit) or 26 bytes (for 104-bit).
+    ///
+    /// # Returns
+    ///
+    /// * `WifiCredentials` - The configured Wi-Fi credentials with WPA-PSK security on success.
+    /// * `StackError` - If parameter validation fails.
+    pub fn wep(ssid: &str, key: &str) -> Result<Self, StackError> {
+        Self::new(ssid, passphrase, AuthType::WEP)
+    }
+
+    /// Creates an wifi configuration from raw byte slices.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID as a byte slice; no more than 32 bytes.
+    /// * `key` - The security key as a byte slice; must meet length requirements based on the `auth` type.
+    /// * `auth` - The authentication method (e.g., Open, WEP, WPA2).
+    ///
+    /// # Returns
+    ///
+    /// * `WifiCredentials` - The configured WifiCredentials on success.
+    /// * `StackError` - If validation of any parameters fails.
+    pub fn from_bytes(ssid: &[u8], key: &[u8], auth: AuthType) -> Result<Self, StackError> {
+        // SSID
+        let mut _ssid = [0u8; MAX_SSID_LEN];
+        let _ssid_len = ssid.len().min(MAX_SSID_LEN);
+        // Passphrase
+        let mut _key = [0u8; MAX_PSK_KEY_LEN];
+        let _key_len = key.len().min(MAX_PSK_KEY_LEN);
+        // Check the key length validity
+        Self::check_key_validity(auth, key.len())?;
+        // Copy the SSID
+        _ssid[.._ssid_len].copy_from_slice(&ssid[.._ssid_len]);
+        // Copy the Passphrase
+        _key[.._key_len].copy_from_slice(&key[.._key_len]);
+        Ok(Self {
+            ssid: _ssid,
+            key: _key,
+            auth,
+        })
+    }
+}
+
+impl AccessPoint {
+    /// Creates a new access point configuration with the provided parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name), up to 32 bytes.
+    /// * `key` - The security key or password, length depends on the `auth` type.
+    /// * `auth` - The authentication method (e.g., Open, WPA2).
+    /// * `channel` - The Wi-Fi channel to operate on (typically between 1 and 14).
+    /// * `ssid_hidden` - Whether the SSID should be hidden from network scans (true for hidden).
+    /// * `ip` - The static IPv4 address to assign to the access point.
+    ///
+    /// # Notes
+    ///
+    /// For WPA, the security key must be at least 8 bytes (MIN) and no more than 63 bytes long.
+    /// For WEP, the security key should be 10 bytes for 40-bit and 26 bytes for 104-bit.
+    ///
+    /// # Returns
+    ///
+    /// * `AccessPoint` - Configured access point structure on success.
+    /// * `StackError` - If validation of any parameters fails.
+    pub fn new(
+        ssid: &str,
+        key: &str,
+        auth: AuthType,
+        channel: WifiChannel,
+        ssid_hidden: bool,
+        ip: Ipv4Addr,
+    ) -> Result<Self, StackError> {
+        let octets = ip.octets();
+        if !((1..100).contains(&octets[3])) {
+            return Err(StackError::WincWifiFail(Error::BufferError));
+        }
+        Ok(Self {
+            credentials: WifiCredentials::new(ssid, key, auth)?,
+            channel,
+            ssid_hidden,
+            ip: Ipv4Addr::from(octets),
+        })
+    }
+
     /// Creates configuration for an open (no security) access point.
-    pub fn open(ssid: &'a str) -> Self {
-        Self {
-            ssid,
-            key: "",
-            channel: 1,
-            auth: AuthType::Open,
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name), up to 32 bytes.
+    ///
+    /// # Returns
+    ///
+    /// * `AccessPoint` - The configured `AccessPoint` with open (no security) on success.
+    /// * `StackError` - If validation of any parameters fails.
+    pub fn open(ssid: &str) -> Result<Self, StackError> {
+        Ok(Self {
+            credentials: WifiCredentials::new(ssid, "", AuthType::Open)?,
+            channel: WifiChannel::Channel1,
             ssid_hidden: false,
-            ip: Ipv4Addr::new(192, 168, 1, 1),
-        }
+            ip: Ipv4Addr::from_bits(PROVISIONING_DEFAULT_IP),
+        })
     }
 
-    #[cfg(feature = "enable-wep")]
+    #[cfg(feature = "wep")]
     /// Creates configuration for a WEP-secured access point.
-    pub fn wep(ssid: &'a str, key: &'a str) -> Self {
-        Self {
-            ssid,
-            key,
-            channel: 1,
-            auth: AuthType::WEP,
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name), up to 32 bytes.
+    /// * `key` - The WEP security key, either 10 bytes (for 40-bit) or 26 bytes (for 104-bit).
+    ///
+    /// # Returns
+    ///
+    /// * `AccessPoint` - The configured `AccessPoint` with WEP security on success.
+    /// * `StackError` - If parameter validation fails.
+    pub fn wep(ssid: &'a str, key: &'a str) -> Result<Self, StackError> {
+        Ok(Self {
+            credentials: WifiCredentials::new(ssid, key, AuthType::WEP)?,
+            channel: WifiChannel::Channel1,
             ssid_hidden: false,
-            ip: Ipv4Addr::new(192, 168, 1, 1),
-        }
+            ip: Ipv4Addr::from_bits(PROVISIONING_DEFAULT_IP),
+        })
     }
 
-    /// Creates configuration for a WPA or WPA2-secured access point.
-    pub fn wpa(ssid: &'a str, key: &'a str) -> Self {
-        Self {
-            ssid,
-            key,
-            channel: 1,
-            auth: AuthType::WpaPSK,
+    /// Creates a configuration for a WPA or WPA2-secured access point.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID (network name), up to 32 bytes.
+    /// * `key` - The WPA security key, up to 63 bytes (as per WPA/WPA2 specification).
+    ///
+    /// # Returns
+    ///
+    /// * `AccessPoint` - The configured `AccessPoint` with WPA-PSK security on success.
+    /// * `StackError` - If parameter validation fails.
+    pub fn wpa(ssid: &str, key: &str) -> Result<Self, StackError> {
+        Ok(Self {
+            credentials: WifiCredentials::new(ssid, key, AuthType::WpaPSK)?,
+            channel: WifiChannel::Channel1,
             ssid_hidden: false,
-            ip: Ipv4Addr::new(192, 168, 1, 1),
-        }
+            ip: Ipv4Addr::from_bits(PROVISIONING_DEFAULT_IP),
+        })
     }
 
-    //pub fn validate_pramaters(& self) -> Result
+    /// Sets the static IP address for the configured access point.
+    ///
+    /// # Arguments
+    ///
+    /// * `ip` - The new static IPv4 address to assign to the access point.
+    ///
+    /// # Warning
+    ///
+    /// Due to a WINC firmware limitation, the client's IP address is always assigned as `x.x.x.100`.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the IP address is successfully set.
+    /// * `StackError` - If the IP address is invalid.
+    pub fn set_ip(&mut self, ip: Ipv4Addr) -> Result<(), StackError> {
+        let octets = ip.octets();
+        // WINC fimrware limitation; IP address of client is always x.x.x.100
+        if !((1..100).contains(&octets[3])) {
+            return Err(StackError::WincWifiFail(Error::BufferError));
+        }
+
+        self.ip = Ipv4Addr::from(octets);
+
+        Ok(())
+    }
+
+    /// Sets the Wi-Fi channel for the configured access point.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel` - The Wi-Fi RF channel to use (typically 1–14).
+    pub fn set_channel(&mut self, channel: WifiChannel) {
+        self.channel = channel;
+    }
 }

--- a/winc-rs/src/manager/net_types.rs
+++ b/winc-rs/src/manager/net_types.rs
@@ -308,6 +308,20 @@ mod tests {
     }
 
     #[test]
+    fn test_ap_set_ip_success() {
+        let ssid = Ssid::from("test").unwrap();
+        let psk = WpaKey::from("test_key").unwrap();
+        let mut ap = AccessPoint::wpa(&ssid, &psk);
+        let ip = Ipv4Addr::new(192, 168, 1, 1);
+
+        assert_eq!(ap.ip, Ipv4Addr::from_bits(DEFAULT_AP_IP));
+
+        let result = ap.set_ip(ip);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_ap_config_fail() {
         let ssid = Ssid::from("test").unwrap();
         let psk = WpaKey::from("test_key").unwrap();

--- a/winc-rs/src/manager/net_types.rs
+++ b/winc-rs/src/manager/net_types.rs
@@ -1,0 +1,71 @@
+use arrayvec::ArrayString;
+
+use super::constants::{AuthType, MAX_PSK_KEY_LEN, MAX_SSID_LEN};
+use core::net::Ipv4Addr;
+
+/// Structure for Access Point Configuration.
+pub struct AccessPoint<'a> {
+    /// The SSID (name) of the access point.
+    pub ssid: &'a str,
+    /// The WPA/WPA2 or WEP key for the access point.
+    pub key: &'a str,
+    /// The channel number (1..14) used by the access point.
+    pub channel: u8,
+    /// The authentication type (e.g., WPA, WPA2, WEP)
+    pub auth: AuthType,
+    /// Whether the SSID is hidden (true for hidden).
+    pub ssid_hidden: bool,
+    /// IP address for access point.
+    pub ip: core::net::Ipv4Addr,
+}
+
+/// Structure for Wi-Fi Credentials.
+pub struct WifiCredentials {
+    /// The SSID (network name) of the network.
+    pub ssid: ArrayString<MAX_SSID_LEN>,
+    /// The passphrase (Wi-Fi key) for the network's security.
+    pub passphrase: ArrayString<MAX_PSK_KEY_LEN>,
+    /// The authentication type (e.g., WPA, WPA2, etc.) used by the network.
+    pub auth: AuthType,
+}
+
+impl<'a> AccessPoint<'a> {
+    /// Creates configuration for an open (no security) access point.
+    pub fn open(ssid: &'a str) -> Self {
+        Self {
+            ssid,
+            key: "",
+            channel: 1,
+            auth: AuthType::Open,
+            ssid_hidden: false,
+            ip: Ipv4Addr::new(192, 168, 1, 1),
+        }
+    }
+
+    #[cfg(feature = "enable-wep")]
+    /// Creates configuration for a WEP-secured access point.
+    pub fn wep(ssid: &'a str, key: &'a str) -> Self {
+        Self {
+            ssid,
+            key,
+            channel: 1,
+            auth: AuthType::WEP,
+            ssid_hidden: false,
+            ip: Ipv4Addr::new(192, 168, 1, 1),
+        }
+    }
+
+    /// Creates configuration for a WPA or WPA2-secured access point.
+    pub fn wpa(ssid: &'a str, key: &'a str) -> Self {
+        Self {
+            ssid,
+            key,
+            channel: 1,
+            auth: AuthType::WpaPSK,
+            ssid_hidden: false,
+            ip: Ipv4Addr::new(192, 168, 1, 1),
+        }
+    }
+
+    //pub fn validate_pramaters(& self) -> Result
+}

--- a/winc-rs/src/manager/requests.rs
+++ b/winc-rs/src/manager/requests.rs
@@ -544,12 +544,8 @@ mod tests {
         let access_point = AccessPoint::wpa(&ap_ssid, &psk);
         let hostname = HostName::from("admin").unwrap();
 
-        let result = write_start_provisioning_req(&access_point, &hostname, false);
+        let result = write_start_provisioning_req(&access_point, &hostname, false).unwrap();
 
-        if let Ok(req) = result {
-            assert_eq!(req, valid_req);
-        } else {
-            assert!(false);
-        }
+        assert_eq!(result, valid_req);
     }
 }

--- a/winc-rs/src/manager/requests.rs
+++ b/winc-rs/src/manager/requests.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrayvec::ArrayString;
-
 use crate::manager::net_types::WpaKey;
 use crate::readwrite::BufferOverflow;
 use crate::readwrite::Write;
@@ -265,7 +263,7 @@ pub fn write_start_provisioning_req(
     #[cfg(not(feature = "wep"))]
     {
         wep_key_index = 0;
-        wep_key = ArrayString::new();
+        wep_key = WepKey::new();
     }
 
     // Set parameters for WPA-PSK

--- a/winc-rs/src/manager/responses.rs
+++ b/winc-rs/src/manager/responses.rs
@@ -701,15 +701,11 @@ mod tests {
             100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
         ];
-        let res = read_provisioning_reply(&buffer);
+        let info = read_provisioning_reply(&buffer).unwrap();
 
-        if let Ok(info) = res {
-            assert_eq!(info.0.as_str(), "test_ssid");
-            assert_eq!(info.1.as_str(), "test_password");
-            assert_eq!(info.2, 2);
-            assert_eq!(info.3, true);
-        } else {
-            assert!(false);
-        }
+        assert_eq!(info.0.as_str(), "test_ssid");
+        assert_eq!(info.1.as_str(), "test_password");
+        assert_eq!(info.2, 2);
+        assert_eq!(info.3, true);
     }
 }

--- a/winc-rs/src/manager/responses.rs
+++ b/winc-rs/src/manager/responses.rs
@@ -431,7 +431,7 @@ pub fn read_prng_reply(mut response: &[u8]) -> Result<(u32, u16), Error> {
 ///
 /// |    SSID    | Passphrase | Security type | Provisioning status |
 /// |------------|------------|---------------|---------------------|
-/// |  33 Bytes  |  65 Bytes  |    2 Bytes    |       1 Byte        |
+/// |  33 Bytes  |  65 Bytes  |    1 Bytes    |       1 Byte        |
 ///
 /// # Arguments
 ///
@@ -691,5 +691,25 @@ mod tests {
     fn test_prng_reply() {
         let buffer = [0xDC, 0x65, 0x00, 0x20, 0x20, 0x00, 0x00, 0x00];
         assert_eq!(read_prng_reply(&buffer).unwrap(), (0x200065DC, 32))
+    }
+
+    #[test]
+    fn test_provisioning_reply() {
+        let buffer = [
+            116, 101, 115, 116, 95, 115, 115, 105, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 101, 115, 116, 95, 112, 97, 115, 115, 119, 111, 114,
+            100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
+        ];
+        let res = read_provisioning_reply(&buffer);
+
+        if let Ok(info) = res {
+            assert_eq!(info.0.as_str(), "test_ssid");
+            assert_eq!(info.1.as_str(), "test_password");
+            assert_eq!(info.2, 2);
+            assert_eq!(info.3, true);
+        } else {
+            assert!(false);
+        }
     }
 }

--- a/winc-rs/src/stack/stack_error.rs
+++ b/winc-rs/src/stack/stack_error.rs
@@ -41,6 +41,8 @@ pub enum StackError {
     ContinueOperation,
     /// Not found
     SocketNotFound,
+    /// Parameters are not valid.
+    InvalidParameters,
 }
 
 impl From<core::convert::Infallible> for StackError {


### PR DESCRIPTION
This PR includes the following changes:
1. Added support for the `Provisioning Mode`.
2. Introduced a separate module to handle the data `types` for network configuration and credentials.
3. Added optional feature to enable the `Wep` network security.
4. Added new error code in `StackError` enum to represent that passed parameters are invalid or not supported.
5. Added example for `provisioning mode`.
6. Added Unit test cases.