### PR TITLE
Socket receive fix for large payloads

### DIFF
--- a/python/client.py
+++ b/python/client.py
@@ -2,12 +2,13 @@ import asyncio
 import argparse
 import logging
 import sys
+import socket
 
 log = logging.getLogger(__name__)
 
-async def send_socket_request(host, port, request_data):
-    # Open a connection to the host:port
-    log.info(f"Connecting to {host}:{port} for {request_data}")
+async def send_tcp_request(host, port, request_data):
+    """Send TCP request using asyncio streams"""
+    log.info(f"TCP: Connecting to {host}:{port} for {request_data[:50]}...")
     reader, writer = await asyncio.open_connection(host, port)
 
     # Send your custom request data
@@ -23,29 +24,73 @@ async def send_socket_request(host, port, request_data):
 
     return response.decode('utf-8')
 
+async def send_udp_request(host, port, request_data):
+    """Send UDP request using asyncio datagram protocol"""
+    log.info(f"UDP: Sending to {host}:{port} for {request_data[:50]}...")
+
+    # Create UDP socket
+    loop = asyncio.get_event_loop()
+
+    # Create a UDP socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setblocking(False)
+
+    try:
+        # Send the data
+        await loop.sock_sendto(sock, request_data.encode('utf-8'), (host, port))
+
+        # Receive the response (with timeout)
+        try:
+            response_data = await asyncio.wait_for(
+                loop.sock_recv(sock, 1024),
+                timeout=5.0  # 5 second timeout
+            )
+            return response_data.decode('utf-8')
+        except asyncio.TimeoutError:
+            log.warning(f"UDP request to {host}:{port} timed out")
+            return "TIMEOUT"
+    finally:
+        sock.close()
+
+async def send_socket_request(host, port, request_data, protocol='tcp'):
+    """Send request using specified protocol"""
+    if protocol.lower() == 'udp':
+        return await send_udp_request(host, port, request_data)
+    else:
+        return await send_tcp_request(host, port, request_data)
+
 async def main():
     parser = argparse.ArgumentParser(description='Send socket requests to a server')
     parser.add_argument('--host', type=str, default='localhost', help='Host address')
     parser.add_argument('--port', type=int, default=80, help='Port number')
+    parser.add_argument('-u', '--udp', action='store_true', help='Use UDP protocol (default is TCP)')
     parser.add_argument('--requests', type=int, default=5, help='Number of requests to send')
-    parser.add_argument('--log_level', choices=["INFO", "DEBUG"] , default="INFO", help='Log level')
+    parser.add_argument('--log_level', choices=["INFO", "DEBUG"], default="INFO", help='Log level')
     args = parser.parse_args()
 
     host = args.host
     port = args.port
+    protocol = 'udp' if args.udp else 'tcp'
 
-    logging.basicConfig(level=args.log_level,stream=sys.stdout)
+    logging.basicConfig(level=args.log_level, stream=sys.stdout)
 
-    requests = [f"GET /?req={i} HTTP/1.1\r\nHost: {args.host}\r\n\r\n" for i in range(1, args.requests + 1)]
+    # Create different request formats based on protocol
+    if protocol == 'udp':
+        # For UDP, use simpler request format (no HTTP headers needed for basic UDP server)
+        requests = [f"UDP request {i}" for i in range(1, args.requests + 1)]
+    else:
+        # For TCP, use HTTP format
+        requests = [f"GET /?req={i} HTTP/1.1\r\nHost: {args.host}\r\n\r\n" for i in range(1, args.requests + 1)]
+
+    log.info(f"Sending {args.requests} {protocol.upper()} requests to {host}:{port}")
 
     # Create tasks for all socket requests
-    tasks = [send_socket_request(host, port, req) for req in requests]
+    tasks = [send_socket_request(host, port, req, protocol) for req in requests]
 
-    for task in asyncio.as_completed(tasks):
+    # Process results as they complete
+    for i, task in enumerate(asyncio.as_completed(tasks), 1):
         result = await task  # Get the result as soon as this task finishes
-        # Find the corresponding request (since order isn't guaranteed)
-        # We could use a dict or tuple in tasks to map requests to results, but for simplicity:
-        print(f"Result from a request: {result[:50]}...")
+        print(f"Result {i}: {result[:100]}...")
 
 # Run the event loop
 if __name__ == "__main__":

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -228,6 +228,25 @@ mod test_shared {
 
 #[cfg(test)]
 mod tests {
+    // Helper function to compute CRC16 for test data integrity verification
+    pub(crate) fn compute_crc16(input: &[u8]) -> u16 {
+        use crc_any::CRC;
+        let mut crc = CRC::crc16aug_ccitt();
+        crc.digest(&[0x99, 0xc0]); // reset crc to 0xFFFF
+        crc.digest(input);
+        crc.get_crc() as u16
+    }
+
+    // Generate a predictable, sequential pattern of u32 values for testing
+    pub(crate) fn generate_test_pattern(buffer: &mut [u8]) {
+        assert!(buffer.len() % 4 == 0, "Buffer size must be a multiple of 4");
+        let mut val: u32 = 0;
+        for chunk in buffer.chunks_mut(4) {
+            chunk.copy_from_slice(&val.to_be_bytes());
+            val = val.wrapping_add(1);
+        }
+    }
+
     #[test]
     fn test_winc_client() {}
 }

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -38,7 +38,7 @@ pub struct WincClient<'a, X: Xfer> {
 }
 
 impl<X: Xfer> WincClient<'_, X> {
-    // Max send frame length
+    // Max send frame length - conservative limit to avoid overwhelming chip buffers
     #[cfg(not(test))]
     const MAX_SEND_LENGTH: usize = 1400;
 

--- a/winc-rs/src/client/tcp_stack.rs
+++ b/winc-rs/src/client/tcp_stack.rs
@@ -785,4 +785,129 @@ mod test {
         let seventh_read = nb::block!(client.receive(&mut tcp_socket, &mut recv_buffer)).unwrap();
         assert_eq!(seventh_read, 0);
     }
+
+    #[test]
+    fn partial_receive_full_test() {
+        // Test case 1: 10KB data, small SPI buffer (31 bytes), large receiver buffer (2KB)
+        // This tests the scenario where SPI delivers small chunks but app has large buffers
+        run_partial_read_test(10240, 31, 2048);
+
+        // Test case 2: 10KB data, small SPI buffer (100 bytes), small receiver buffer (100 bytes)
+        // This tests equal sized buffers under the builtin buffer sizes
+        run_partial_read_test(10240, 100, 100);
+
+        // Test case 3: 10KB data, equal SPI and receiver buffers (64 bytes)
+        // Another equal size test with smaller buffers
+        run_partial_read_test(10240, 64, 64);
+
+        // Test case 4: 10KB data, large SPI buffer (1024 bytes), small receiver buffer (31 bytes)
+        // This tests large SPI chunks but tiny app reads
+        run_partial_read_test(10240, 1024, 31);
+
+        // Test case 5: 10KB data, large SPI buffer (1024 bytes), small receiver buffer (100 bytes)
+        // Large SPI with medium app reads
+        run_partial_read_test(10240, 1024, 100);
+
+        // Test case 6: 10KB data, equal larger buffers (1024 bytes each)
+        // This tests equal sized large buffers
+        run_partial_read_test(10240, 1024, 1024);
+
+        // Test case 7: 10KB data, equal large buffers (1400 bytes each - near MTU limit)
+        // This tests the largest practical equal buffer sizes
+        run_partial_read_test(10240, 1400, 1400);
+
+        // Test case 8: Edge case - tiny data, large buffers
+        run_partial_read_test(64, 1024, 1400);
+
+        // Test case 9: Edge case - data that doesn't align with 4-byte boundaries nicely
+        run_partial_read_test(9996, 97, 131); // Non-round numbers to test edge cases
+    }
+
+    fn run_partial_read_test(total_size: usize, spi_chunk_size: usize, receive_buffer_size: usize) {
+        let mut client = make_test_client();
+        let mut socket_handle = client.socket().unwrap();
+        let socket_addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80);
+
+        // Prepare test data pattern
+        let mut source_data = [0u8; 10240];
+        assert!(total_size <= source_data.len());
+        let source_slice = &mut source_data[0..total_size];
+        crate::client::tests::generate_test_pattern(source_slice);
+        let expected_checksum = crate::client::tests::compute_crc16(source_slice);
+
+        // Storage for received data
+        let mut received_data = [0u8; 10240];
+        let mut app_receive_buffer = [0u8; 2048];
+        assert!(receive_buffer_size <= app_receive_buffer.len());
+
+        // Start the initial receive call to put socket in pending state
+        let initial_result = client.receive(
+            &mut socket_handle,
+            &mut app_receive_buffer[0..receive_buffer_size],
+        );
+        assert_eq!(initial_result, Err(nb::Error::WouldBlock));
+
+        let mut total_bytes_received = 0;
+        let mut spi_offset = 0;
+
+        // Simulate SPI data arriving in chunks
+        while spi_offset < total_size {
+            let chunk_end = (spi_offset + spi_chunk_size).min(total_size);
+            let chunk = &source_slice[spi_offset..chunk_end];
+
+            // Copy chunk to internal buffer and trigger callback
+            client.callbacks.recv_buffer[..chunk.len()].copy_from_slice(chunk);
+            client
+                .callbacks
+                .on_recv(Socket::new(0, 0), socket_addr, chunk, SocketError::NoError);
+
+            spi_offset = chunk_end;
+
+            // Read all available data with the specified receiver buffer size
+            loop {
+                let receive_slice = &mut app_receive_buffer[0..receive_buffer_size];
+                let read_result = client.receive(&mut socket_handle, receive_slice);
+
+                match read_result {
+                    Ok(bytes_read) => {
+                        if bytes_read == 0 {
+                            break; // No more data from this SPI chunk
+                        }
+
+                        // Copy received data to our accumulator
+                        received_data[total_bytes_received..total_bytes_received + bytes_read]
+                            .copy_from_slice(&receive_slice[0..bytes_read]);
+                        total_bytes_received += bytes_read;
+                    }
+                    Err(nb::Error::WouldBlock) => {
+                        break; // Need more SPI data
+                    }
+                    Err(e) => {
+                        panic!("Unexpected error: {:?}", e);
+                    }
+                }
+            }
+        }
+
+        // Verify all data was received correctly
+        assert_eq!(
+            total_bytes_received, total_size,
+            "Total bytes received {} != expected {} (SPI: {}, RX: {})",
+            total_bytes_received, total_size, spi_chunk_size, receive_buffer_size
+        );
+
+        let received_slice = &received_data[0..total_size];
+        let actual_checksum = crate::client::tests::compute_crc16(received_slice);
+        assert_eq!(
+            actual_checksum, expected_checksum,
+            "Checksum mismatch! (SPI: {}, RX: {})",
+            spi_chunk_size, receive_buffer_size
+        );
+
+        assert_eq!(
+            received_slice, source_slice,
+            "Data content mismatch! (SPI: {}, RX: {})",
+            spi_chunk_size, receive_buffer_size
+        );
+    }
 }

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -626,4 +626,139 @@ mod test {
         assert_eq!(sixth_read, (256, core::net::SocketAddr::V4(socket_addr)));
         assert!(recv_buffer.iter().all(|&x| x == 0x55));
     }
+
+    #[test]
+    fn partial_receive_full_test() {
+        // Test case 1: 10KB data, small SPI buffer (31 bytes), large receiver buffer (1400 bytes)
+        // This tests the scenario where SPI delivers small chunks but app has large buffers
+        run_udp_partial_read_test(10240, 31, 1400);
+
+        // Test case 2: 10KB data, small SPI buffer (100 bytes), small receiver buffer (100 bytes)
+        // This tests equal sized buffers under the builtin buffer sizes
+        run_udp_partial_read_test(10240, 100, 100);
+
+        // Test case 3: 10KB data, equal SPI and receiver buffers (64 bytes)
+        // Another equal size test with smaller buffers
+        run_udp_partial_read_test(10240, 64, 64);
+
+        // Test case 4: 10KB data, large SPI buffer (1024 bytes), small receiver buffer (31 bytes)
+        // This tests large SPI chunks but tiny app reads
+        run_udp_partial_read_test(10240, 1024, 31);
+
+        // Test case 5: 10KB data, large SPI buffer (1024 bytes), small receiver buffer (100 bytes)
+        // Large SPI with medium app reads
+        run_udp_partial_read_test(10240, 1024, 100);
+
+        // Test case 6: 10KB data, equal larger buffers (1024 bytes each)
+        // This tests equal sized large buffers
+        run_udp_partial_read_test(10240, 1024, 1024);
+
+        // Test case 7: 10KB data, equal large buffers (1400 bytes each - near MTU limit)
+        // This tests the largest practical equal buffer sizes
+        run_udp_partial_read_test(10240, 1400, 1400);
+
+        // Test case 8: Edge case - tiny data, large buffers
+        run_udp_partial_read_test(64, 1024, 1400);
+
+        // Test case 9: Edge case - data that doesn't align with 4-byte boundaries nicely
+        run_udp_partial_read_test(9996, 97, 131); // Non-round numbers to test edge cases
+    }
+
+    fn run_udp_partial_read_test(
+        total_size: usize,
+        spi_chunk_size: usize,
+        receive_buffer_size: usize,
+    ) {
+        let mut client = make_test_client();
+        let mut socket_handle = client.socket().unwrap();
+        let socket_addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80);
+
+        // Prepare test data pattern
+        let mut source_data = [0u8; 10240];
+        assert!(total_size <= source_data.len());
+        let source_slice = &mut source_data[0..total_size];
+        crate::client::tests::generate_test_pattern(source_slice);
+        let expected_checksum = crate::client::tests::compute_crc16(source_slice);
+
+        // Storage for received data
+        let mut received_data = [0u8; 10240];
+        let mut app_receive_buffer = [0u8; 1400];
+        assert!(receive_buffer_size <= app_receive_buffer.len());
+
+        // Start the initial receive call to put socket in pending state
+        let initial_result = client.receive(
+            &mut socket_handle,
+            &mut app_receive_buffer[0..receive_buffer_size],
+        );
+        assert_eq!(initial_result, Err(nb::Error::WouldBlock));
+
+        let mut total_bytes_received = 0;
+        let mut spi_offset = 0;
+
+        // Simulate SPI data arriving in chunks
+        while spi_offset < total_size {
+            let chunk_end = (spi_offset + spi_chunk_size).min(total_size);
+            let chunk = &source_slice[spi_offset..chunk_end];
+
+            // Copy chunk to internal buffer and trigger callback
+            client.callbacks.recv_buffer[..chunk.len()].copy_from_slice(chunk);
+            client.callbacks.on_recvfrom(
+                Socket::new(7, 0), // UDP uses socket ID 7,0
+                socket_addr,
+                chunk,
+                SocketError::NoError,
+            );
+
+            spi_offset = chunk_end;
+
+            // Read all available data with the specified receiver buffer size
+            loop {
+                let receive_slice = &mut app_receive_buffer[0..receive_buffer_size];
+                let read_result = client.receive(&mut socket_handle, receive_slice);
+
+                match read_result {
+                    Ok((bytes_read, addr)) => {
+                        if bytes_read == 0 {
+                            break; // No more data from this SPI chunk
+                        }
+
+                        // Verify the address matches
+                        assert_eq!(addr, core::net::SocketAddr::V4(socket_addr));
+
+                        // Copy received data to our accumulator
+                        received_data[total_bytes_received..total_bytes_received + bytes_read]
+                            .copy_from_slice(&receive_slice[0..bytes_read]);
+                        total_bytes_received += bytes_read;
+                    }
+                    Err(nb::Error::WouldBlock) => {
+                        break; // Need more SPI data
+                    }
+                    Err(e) => {
+                        panic!("Unexpected error: {:?}", e);
+                    }
+                }
+            }
+        }
+
+        // Verify all data was received correctly
+        assert_eq!(
+            total_bytes_received, total_size,
+            "Total bytes received {} != expected {} (SPI: {}, RX: {})",
+            total_bytes_received, total_size, spi_chunk_size, receive_buffer_size
+        );
+
+        let received_slice = &received_data[0..total_size];
+        let actual_checksum = crate::client::tests::compute_crc16(received_slice);
+        assert_eq!(
+            actual_checksum, expected_checksum,
+            "Checksum mismatch! (SPI: {}, RX: {})",
+            spi_chunk_size, receive_buffer_size
+        );
+
+        assert_eq!(
+            received_slice, source_slice,
+            "Data content mismatch! (SPI: {}, RX: {})",
+            spi_chunk_size, receive_buffer_size
+        );
+    }
 }

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -239,7 +239,13 @@ impl<X: Xfer> UdpClientStack for WincClient<'_, X> {
         );
         self.test_hook();
         match res {
-            Ok(len) => Ok((len, core::net::SocketAddr::V4(from_addr.unwrap()))),
+            Ok(len) => {
+                if let Some(addr) = from_addr {
+                    Ok((len, core::net::SocketAddr::V4(addr)))
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
             Err(nb::Error::Other(StackError::ContinueOperation)) => Err(nb::Error::WouldBlock),
             Err(nb::Error::Other(e)) => Err(nb::Error::Other(e)),
             Err(nb::Error::WouldBlock) => Err(nb::Error::WouldBlock),

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -88,7 +88,7 @@ const ETHERNET_HEADER_LENGTH: usize = 14;
 const ETHERNET_HEADER_OFFSET: usize = 34;
 const IP_PACKET_OFFSET: usize = ETHERNET_HEADER_LENGTH + ETHERNET_HEADER_OFFSET; // - HIF_HEADER_OFFSET;
 
-pub const SOCKET_BUFFER_MAX_LENGTH: usize = 1400;
+pub const SOCKET_BUFFER_MAX_LENGTH: usize = 1500; // Receive buffer - must handle full MTU from chip (1440+ bytes observed)
 pub const PRNG_PACKET_SIZE: usize = 8;
 
 #[cfg(feature = "large_rng")]

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -148,16 +148,18 @@ pub(crate) struct RecvResult {
     pub recv_len: usize,
     pub from_addr: core::net::SocketAddrV4,
     pub error: SocketError,
+    pub return_offset: usize, // Track how much data has been returned to caller
 }
 #[cfg(feature = "defmt")]
 impl defmt::Format for RecvResult {
     fn format(&self, f: defmt::Formatter) {
         defmt::write!(
             f,
-            "recv_len: {}, from_addr: {:?}, error: {}",
+            "recv_len: {}, from_addr: {:?}, error: {}, return_offset: {}",
             self.recv_len,
             Ipv4AddrFormatWrapper::new(self.from_addr.ip()),
-            self.error
+            self.error,
+            self.return_offset
         );
     }
 }
@@ -468,6 +470,7 @@ impl EventListener for SocketCallbacks {
                     recv_len: data.len(),
                     from_addr: address,
                     error: err,
+                    return_offset: 0,
                 });
                 *asyncstate = AsyncState::Done;
                 self.recv_buffer[..data.len()].copy_from_slice(data);
@@ -512,6 +515,7 @@ impl EventListener for SocketCallbacks {
                     recv_len: data.len(),
                     from_addr: address,
                     error: err,
+                    return_offset: 0,
                 });
                 *asyncstate = AsyncState::Done;
                 self.recv_buffer[..data.len()].copy_from_slice(data);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of partial data reads in TCP and UDP receive operations, enabling large packets to be processed incrementally across multiple calls.
  - Increased the receive buffer size to better accommodate larger network packets.

- **New Features**
  - Added support for UDP socket communication in the client with a new protocol selection option.
  - Enhanced debugging with additional logging for partial and complete reads.
  - Added tests verifying correct handling of large payloads for both TCP and UDP.

- **Refactor**
  - Updated internal data structures to track how much data has been returned to the caller during receive operations.
  - Refactored socket request sending logic to separate TCP and UDP handling.

- **Documentation**
  - Clarified comments regarding buffer length limits to better explain their intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->