### PR TITLE
Change SPI default speed to 8mhz

### DIFF
--- a/feather/src/init.rs
+++ b/feather/src/init.rs
@@ -20,7 +20,7 @@ use hal::ehal::i2c::I2c;
 
 use super::shared::SpiBus;
 
-// Set SPI bus to 4 Mhz, about as fast as it goes
+// Set SPI bus to 8 Mhz, about as fast as it goes
 const SPI_MHZ: u32 = 8;
 const I2C_KHZ: u32 = 400;
 

--- a/feather/src/init.rs
+++ b/feather/src/init.rs
@@ -21,7 +21,7 @@ use hal::ehal::i2c::I2c;
 use super::shared::SpiBus;
 
 // Set SPI bus to 4 Mhz, about as fast as it goes
-const SPI_MHZ: u32 = 4;
+const SPI_MHZ: u32 = 8;
 const I2C_KHZ: u32 = 400;
 
 use cortex_m_systick_countdown::{PollingSysTick, SysTickCalibration};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Increased the SPI bus frequency from 4 MHz to 8 MHz, resulting in faster SPI communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->