### PR TITLE
Added error handling for default connect response

### DIFF
--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -95,9 +95,13 @@ impl<X: Xfer> WincClient<'_, X> {
                 }
                 Err(nb::Error::WouldBlock)
             }
-            WifiModuleState::ConnectionFailed => Err(nb::Error::Other(StackError::ApJoinFailed(
-                self.callbacks.connection_state.conn_error.take().unwrap(),
-            ))),
+            WifiModuleState::ConnectionFailed => {
+                // Change the state to `Unconnected` so that the client can make subsequent connection requests.
+                self.callbacks.state = WifiModuleState::Unconnected;
+                Err(nb::Error::Other(StackError::ApJoinFailed(
+                    self.callbacks.connection_state.conn_error.take().unwrap(),
+                )))
+            }
             WifiModuleState::ConnectedToAp => {
                 info!("connect_to_ap: got Connected to AP");
                 Ok(())

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -4,7 +4,7 @@ use embedded_nal::nb;
 
 use crate::error;
 use crate::manager::{AccessPoint, AuthType, FirmwareInfo, IPConf, ScanResult};
-use crate::manager::{Credentials, HostName, ProvisioningInfo};
+use crate::manager::{Credentials, HostName, ProvisioningInfo, WifiConnError};
 
 use super::PingResult;
 use super::StackError;
@@ -99,7 +99,11 @@ impl<X: Xfer> WincClient<'_, X> {
                 // Change the state to `Unconnected` so that the client can make subsequent connection requests.
                 self.callbacks.state = WifiModuleState::Unconnected;
                 Err(nb::Error::Other(StackError::ApJoinFailed(
-                    self.callbacks.connection_state.conn_error.take().unwrap(),
+                    self.callbacks
+                        .connection_state
+                        .conn_error
+                        .take()
+                        .unwrap_or(WifiConnError::Unhandled),
                 )))
             }
             WifiModuleState::ConnectedToAp => {

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -111,7 +111,7 @@ const MAX_SOCKET: usize = TCP_SOCK_MAX + UDP_SOCK_MAX;
 pub trait EventListener {
     fn on_rssi(&mut self, level: i8);
     fn on_resolve(&mut self, ip: Ipv4Addr, host: &str);
-    fn on_default_connect(&mut self, connected: bool);
+    fn on_default_connect(&mut self, status: WifiConnError);
     fn on_dhcp(&mut self, conf: IPConf);
     fn on_connstate_changed(&mut self, state: WifiConnState, err: WifiConnError);
     fn on_connection_info(&mut self, info: ConnectionInfo);
@@ -863,7 +863,7 @@ impl<X: Xfer> Manager<X> {
                 WifiResponse::DefaultConnect => {
                     let mut def_connect = [0xff; 4];
                     self.read_block(address, &mut def_connect)?;
-                    listener.on_default_connect(def_connect[0] == 0)
+                    listener.on_default_connect(def_connect[0].into())
                 }
                 WifiResponse::DhcpConf => {
                     let mut result = [0xff; 20];

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -58,22 +58,30 @@ impl From<Regs> for u32 {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq)]
 pub enum WifiConnError {
-    Unhandled,
+    NoError,
     ScanFail,
     JoinFail,
     AuthFail,
     AssocFail,
     ConnInProgress,
+    ConnListEmpty,
+    Unhandled,
 }
 
 impl From<u8> for WifiConnError {
     fn from(val: u8) -> Self {
         match val {
+            0 => Self::NoError,
             1 => Self::ScanFail,
             2 => Self::JoinFail,
             3 => Self::AuthFail,
             4 => Self::AssocFail,
             5 => Self::ConnInProgress,
+            /* Error codes for default connection response */
+            232 => Self::ConnInProgress,
+            233 => Self::JoinFail,
+            234 => Self::ScanFail,
+            235 => Self::ConnListEmpty,
             _ => Self::Unhandled,
         }
     }

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -267,8 +267,16 @@ impl EventListener for SocketCallbacks {
         self.dns_resolved_addr = Some(Some(ip));
     }
 
-    fn on_default_connect(&mut self, connected: bool) {
-        debug!("client: got connected {}", connected)
+    fn on_default_connect(&mut self, status: WifiConnError) {
+        debug!(
+            "client: got connected {}",
+            (status == WifiConnError::NoError)
+        );
+
+        if (self.state == WifiModuleState::ConnectingToAp) && (status != WifiConnError::NoError) {
+            self.state = WifiModuleState::ConnectionFailed;
+            self.connection_state.conn_error = Some(status);
+        }
     }
     fn on_dhcp(&mut self, conf: crate::manager::IPConf) {
         debug!("client: on_dhcp: IP config: {}", conf);


### PR DESCRIPTION
This PR includes following changes:
1. Added error handling for default connect response.
2. Fixed a bug in the state transition of `WifiModuleState`. If the connection to an access point failed on the first attempt, subsequent attempts would not succeed because the `WifiModuleState` was set to `ConnectionFailed` instead of `Unconnected`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Wi-Fi connection error reporting with more detailed status codes.
- **Bug Fixes**
	- Improved handling of failed Wi-Fi connections, allowing users to retry connecting after a failure.
- **Refactor**
	- Updated event notifications to provide richer connection status information instead of a simple success/failure indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->