### PR TITLE
Cleaner api

### DIFF
--- a/demos/src/bin/main.rs
+++ b/demos/src/bin/main.rs
@@ -141,7 +141,7 @@ fn main() -> Result<(), LocalErrors> {
     let ip_addr = Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]);
     let port = cli.port.unwrap_or(80);
 
-    let mut stack = Stack::default();
+    let mut stack = Stack;
 
     match cli.mode {
         Mode::HttpClient => {
@@ -187,7 +187,7 @@ fn main() -> Result<(), LocalErrors> {
 
             println!("=== HTTP Speed Test ===");
             println!("Server: {} ({})", test_config.server_host, server_addr);
-            println!("File: {}", test_file);
+            println!("File: {test_file}");
 
             // Create timing function using std::time::Instant
             let start_time = Instant::now();
@@ -211,7 +211,7 @@ fn main() -> Result<(), LocalErrors> {
                     );
                 }
                 Err(e) => {
-                    eprintln!("Speed test failed: {:?}", e);
+                    eprintln!("Speed test failed: {e:?}");
                     return Err(LocalErrors::IoError);
                 }
             }

--- a/demos/src/http_server.rs
+++ b/demos/src/http_server.rs
@@ -3,7 +3,7 @@ use embedded_nal::nb::block;
 use embedded_nal::TcpFullStack;
 
 use super::SocketAddrWrap;
-fn usize_to_decimal_string<'a>(value: usize, buffer: &'a mut [u8]) -> &'a str {
+fn usize_to_decimal_string(value: usize, buffer: &mut [u8]) -> &str {
     if buffer.len() < 20 {
         return ""; // Return empty string if buffer is too small
     }

--- a/demos/src/lib.rs
+++ b/demos/src/lib.rs
@@ -1,5 +1,7 @@
 // make this no_std
 #![no_std]
+// Dual logging system compatibility: defmt doesn't support modern format syntax
+#![allow(clippy::uninlined_format_args)]
 
 // Compile-time checks for logging features
 #[cfg(all(feature = "defmt", feature = "log"))]

--- a/demos/src/telnet_shell.rs
+++ b/demos/src/telnet_shell.rs
@@ -127,7 +127,7 @@ where
         let mut menu_buffer = [0; 128];
         let mut context = Context { close: false };
         let output = Output {
-            stack: stack,
+            stack,
             sock: client_sock,
         };
         let mut runner = Runner::new(root_menu, &mut menu_buffer, output, &mut context);

--- a/demos/src/telnet_shell/errwrap.rs
+++ b/demos/src/telnet_shell/errwrap.rs
@@ -28,7 +28,7 @@ where
         embedded_io::ErrorKind::Other
     }
 }
-impl<'a, T, E> From<E> for ErrWrap<T, E>
+impl<T, E> From<E> for ErrWrap<T, E>
 where
     T: TcpFullStack<Error = E> + Sized,
     E: core::fmt::Debug,

--- a/feather/src/lib.rs
+++ b/feather/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_main]
 #![no_std]
+// Dual logging system compatibility: defmt doesn't support modern format syntax
+#![allow(clippy::uninlined_format_args)]
 
 // Compile-time checks for logging features
 #[cfg(all(feature = "defmt", feature = "log"))]

--- a/winc-rs/src/async_client/mod.rs
+++ b/winc-rs/src/async_client/mod.rs
@@ -73,10 +73,10 @@ mod tests {
     }
 
     impl Xfer for MockTransfer {
-        fn recv(&mut self, _: &mut [u8]) -> Result<(), crate::errors::Error> {
+        fn recv(&mut self, _: &mut [u8]) -> Result<(), crate::errors::CommError> {
             Ok(())
         }
-        fn send(&mut self, _: &[u8]) -> Result<(), crate::errors::Error> {
+        fn send(&mut self, _: &[u8]) -> Result<(), crate::errors::CommError> {
             Ok(())
         }
     }

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -233,10 +233,10 @@ mod test_shared {
     }
 
     impl Xfer for MockTransfer {
-        fn recv(&mut self, _: &mut [u8]) -> Result<(), crate::errors::Error> {
+        fn recv(&mut self, _: &mut [u8]) -> Result<(), crate::errors::CommError> {
             Ok(())
         }
-        fn send(&mut self, _: &[u8]) -> Result<(), crate::errors::Error> {
+        fn send(&mut self, _: &[u8]) -> Result<(), crate::errors::CommError> {
             Ok(())
         }
     }

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -1,4 +1,4 @@
-use crate::errors::Error;
+use crate::errors::CommError as Error;
 
 use embedded_nal::nb;
 
@@ -74,7 +74,7 @@ impl<X: Xfer> WincClient<'_, X> {
 
     fn connect_to_ap_impl(
         &mut self,
-        connect_fn: impl FnOnce(&mut Self) -> Result<(), crate::errors::Error>,
+        connect_fn: impl FnOnce(&mut Self) -> Result<(), crate::errors::CommError>,
     ) -> nb::Result<(), StackError> {
         match self.callbacks.state {
             WifiModuleState::Reset | WifiModuleState::Starting | WifiModuleState::Disconnecting => {
@@ -436,7 +436,7 @@ mod tests {
     use super::*;
     use crate::client::{test_shared::*, SocketCallbacks};
     //use crate::manager::Error::BootRomStart;
-    use crate::errors::Error;
+    use crate::errors::CommError as Error;
     use crate::manager::Ssid;
     use crate::manager::{EventListener, PingError, WifiConnError, WifiConnState};
     use crate::{ConnectionInfo, Credentials, S8Password, S8Username, WifiChannel, WpaKey};

--- a/winc-rs/src/errors.rs
+++ b/winc-rs/src/errors.rs
@@ -83,15 +83,8 @@ impl core::fmt::Display for CommError {
             Self::WriteError => "Write error",
             Self::BufferReadError => "Buffer read error",
             Self::UnexpectedAddressFamily => "Unexpected address family",
-            Self::Utf8Error(err) => {
-                return write!(
-                    f,
-                    "UTF-8 error: invalid sequence at position {}, error length: {:?}",
-                    err.valid_up_to(),
-                    err.error_len()
-                )
-            }
-            Self::CapacityError(_) => return write!(f, "Capacity error: array full"),
+            Self::Utf8Error(err) => return write!(f, "UTF-8 error: {}", err),
+            Self::CapacityError(err) => return write!(f, "Capacity error: {}", err),
             Self::BootRomStart => "WiFi module boot ROM start failed",
             Self::FirmwareStart => "WiFi module firmware start failed",
             Self::HifSendFailed => "HIF send failed",

--- a/winc-rs/src/errors.rs
+++ b/winc-rs/src/errors.rs
@@ -134,7 +134,3 @@ impl defmt::Format for CommError {
         }
     }
 }
-
-/// Backward compatibility alias for CommError
-/// TODO: Remove this alias and update all usages to CommError
-pub type Error = CommError;

--- a/winc-rs/src/errors.rs
+++ b/winc-rs/src/errors.rs
@@ -19,7 +19,6 @@ use crate::readwrite::{BufferOverflow, ReadExactError};
 pub enum CommError {
     Failed,
     BufferError,
-    VectorCapacityError,
     // From where, which byte, expected, actual
     ProtocolByteError(&'static str, usize, u8, u8),
     ReadError,
@@ -71,7 +70,6 @@ impl core::fmt::Display for CommError {
         let msg = match self {
             Self::Failed => "Operation failed",
             Self::BufferError => "Buffer error",
-            Self::VectorCapacityError => "Vector capacity error",
             Self::ProtocolByteError(loc, byte, expected, actual) => {
                 return write!(
                     f,
@@ -99,7 +97,6 @@ impl defmt::Format for CommError {
         match self {
             Self::Failed => defmt::write!(f, "Operation failed"),
             Self::BufferError => defmt::write!(f, "Buffer error"),
-            Self::VectorCapacityError => defmt::write!(f, "Vector capacity error"),
             Self::ProtocolByteError(loc, byte, expected, actual) => {
                 defmt::write!(
                     f,

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -76,7 +76,7 @@ mod readwrite;
 mod socket;
 mod stack;
 mod transfer;
-pub use errors::Error as CommError;
+pub use errors::CommError;
 pub use transfer::Xfer as Transfer;
 
 pub use client::PingResult;

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Dual logging system compatibility: defmt doesn't support modern format syntax
+#![allow(clippy::uninlined_format_args)]
+
 //! ATWINC1500 Wifi module library
 //!
 //! NOTE: This very much Work In Progress

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -101,40 +101,6 @@ mod async_client;
 #[cfg(feature = "async")]
 pub use async_client::AsyncClient;
 
-// TODO: Merge this into CommError
-#[derive(Debug, PartialEq)]
-pub enum StrError {
-    Utf8Error(core::str::Utf8Error),
-    CapacityError(arrayvec::CapacityError),
-}
-
-impl From<core::str::Utf8Error> for StrError {
-    fn from(v: core::str::Utf8Error) -> Self {
-        Self::Utf8Error(v)
-    }
-}
-
-impl From<arrayvec::CapacityError> for StrError {
-    fn from(v: arrayvec::CapacityError) -> Self {
-        Self::CapacityError(v)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for StrError {
-    fn format(&self, f: defmt::Formatter) {
-        match self {
-            Self::Utf8Error(e) => defmt::write!(
-                f,
-                "UTF-8 error: invalid sequence at position {}, error length: {:?}",
-                e.valid_up_to(),
-                e.error_len()
-            ),
-            Self::CapacityError(_) => defmt::write!(f, "Capacity error: array full"),
-        }
-    }
-}
-
 pub(crate) struct HexWrap<'a> {
     v: &'a [u8],
 }

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Low-level chip manager
-use crate::errors::Error;
+use crate::errors::CommError as Error;
 use core::fmt::Debug;
 
 use crate::socket::Socket;

--- a/winc-rs/src/manager/chip_access.rs
+++ b/winc-rs/src/manager/chip_access.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::errors::Error;
+use crate::errors::CommError as Error;
 
 use crate::transfer::*;
 

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -411,7 +411,7 @@ impl core::fmt::Display for SocketError {
     }
 }
 
-// Wi-Fi RF Channels
+/// Wi-Fi RF Channels
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WifiChannel {

--- a/winc-rs/src/manager/responses.rs
+++ b/winc-rs/src/manager/responses.rs
@@ -25,8 +25,8 @@ use super::net_types::{HostName, Ssid};
 use arrayvec::ArrayString;
 
 use crate::error;
+use crate::errors::CommError;
 use crate::HexWrap;
-use crate::StrError;
 use core::str::FromStr;
 
 #[cfg(feature = "defmt")]
@@ -74,7 +74,7 @@ fn from_c_byte_str<const N: usize>(input: [u8; N]) -> Result<ArrayString<N>, cor
     Ok(ret)
 }
 
-fn from_c_byte_slice<const N: usize>(input: &[u8]) -> Result<ArrayString<N>, StrError> {
+fn from_c_byte_slice<const N: usize>(input: &[u8]) -> Result<ArrayString<N>, CommError> {
     let slice = match core::str::from_utf8(input) {
         Err(err) => core::str::from_utf8(&input[..err.valid_up_to()])?,
         Ok(s) => s,

--- a/winc-rs/src/manager/responses.rs
+++ b/winc-rs/src/manager/responses.rs
@@ -18,14 +18,13 @@ use core::net::{Ipv4Addr, SocketAddrV4};
 use super::constants::MAX_HOST_NAME_LEN;
 use super::constants::{AuthType, PingError, SocketError, MAX_PSK_KEY_LEN, MAX_SSID_LEN};
 use super::WpaKey;
-use crate::errors::Error;
+use crate::errors::CommError as Error;
 type ErrType<'a> = ReadExactError<<&'a [u8] as Read>::ReadError>;
 
 use super::net_types::{HostName, Ssid};
 use arrayvec::ArrayString;
 
 use crate::error;
-use crate::errors::CommError;
 use crate::HexWrap;
 use core::str::FromStr;
 
@@ -74,7 +73,7 @@ fn from_c_byte_str<const N: usize>(input: [u8; N]) -> Result<ArrayString<N>, cor
     Ok(ret)
 }
 
-fn from_c_byte_slice<const N: usize>(input: &[u8]) -> Result<ArrayString<N>, CommError> {
+fn from_c_byte_slice<const N: usize>(input: &[u8]) -> Result<ArrayString<N>, Error> {
     let slice = match core::str::from_utf8(input) {
         Err(err) => core::str::from_utf8(&input[..err.valid_up_to()])?,
         Ok(s) => s,

--- a/winc-rs/src/stack/stack_error.rs
+++ b/winc-rs/src/stack/stack_error.rs
@@ -18,13 +18,13 @@ pub enum StackError {
     SocketAlreadyInUse,
     CloseFailed,
     Unexpected,
-    DispatchError(crate::errors::Error),
-    ConnectSendFailed(crate::errors::Error),
-    ReceiveFailed(crate::errors::Error),
-    SendSendFailed(crate::errors::Error),
-    SendCloseFailed(crate::errors::Error),
-    BindFailed(crate::errors::Error),
-    WincWifiFail(crate::errors::Error),
+    DispatchError(crate::errors::CommError),
+    ConnectSendFailed(crate::errors::CommError),
+    ReceiveFailed(crate::errors::CommError),
+    SendSendFailed(crate::errors::CommError),
+    SendCloseFailed(crate::errors::CommError),
+    BindFailed(crate::errors::CommError),
+    WincWifiFail(crate::errors::CommError),
     OpFailed(SocketError),
     /// DNS lookup timed out
     DnsTimeout,
@@ -57,8 +57,8 @@ impl From<SocketError> for StackError {
     }
 }
 
-impl From<crate::errors::Error> for StackError {
-    fn from(inner: crate::errors::Error) -> Self {
+impl From<crate::errors::CommError> for StackError {
+    fn from(inner: crate::errors::CommError) -> Self {
         Self::WincWifiFail(inner)
     }
 }

--- a/winc-rs/src/transfer.rs
+++ b/winc-rs/src/transfer.rs
@@ -14,7 +14,7 @@
 
 use crate::readwrite::{Read, Write};
 
-use crate::errors::Error;
+use crate::errors::CommError;
 
 /// Trait for reading and writing data
 pub(crate) trait ReadWrite: Read + Write {}
@@ -25,9 +25,9 @@ impl<U> ReadWrite for U where U: Read + Write {}
 /// There is an example SPI implementantion in demo crate.
 pub trait Xfer {
     /// Receive data from the chip
-    fn recv(&mut self, dest: &mut [u8]) -> Result<(), Error>;
+    fn recv(&mut self, dest: &mut [u8]) -> Result<(), CommError>;
     /// Send data to the chip
-    fn send(&mut self, src: &[u8]) -> Result<(), Error>;
+    fn send(&mut self, src: &[u8]) -> Result<(), CommError>;
     /// Optionally reduce bus wait times after initialization.
     /// This speeds up the overall communications
     fn switch_to_high_speed(&mut self) {}
@@ -44,11 +44,11 @@ impl<U> Xfer for U
 where
     U: ReadWrite,
 {
-    fn recv(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.read_exact(dest).map_err(|_| Error::ReadError)
+    fn recv(&mut self, dest: &mut [u8]) -> Result<(), CommError> {
+        self.read_exact(dest).map_err(|_| CommError::ReadError)
     }
-    fn send(&mut self, src: &[u8]) -> Result<(), Error> {
-        self.write(src).map_err(|_| Error::WriteError)?;
+    fn send(&mut self, src: &[u8]) -> Result<(), CommError> {
+        self.write(src).map_err(|_| CommError::WriteError)?;
         Ok(())
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the main error type to `CommError` and updated all references throughout the codebase.
  * Enhanced error enum with more specific variants and detailed error messages.
  * Updated error formatting for improved logging compatibility.
  * Improved documentation comments for better clarity in generated docs.
  * Simplified code with removal of unused lifetime parameters and streamlined struct initializations.
  * Added lint allowances to support compatibility with dual logging systems.

* **Bug Fixes**
  * Improved error reporting for string and capacity errors, providing more informative messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->