### PR TITLE
Support for the Access Point mode.

### DIFF
--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -45,7 +45,7 @@
 //! // spi: something that implements the protocol transfer
 //! let mut client = WincClient::new(spi);
 //! let ssid = Ssid::from("ssid").unwrap();
-//! let key = Credentials::WpaPSK(WpaKey::from("password").unwrap());
+//! let key = Credentials::from_wpa("password").unwrap();
 //! nb::block!(client.start_wifi_module());
 //! nb::block!(client.connect_to_ap(&ssid, &key, WifiChannel::ChannelAll, false));
 //! nb::block!(client.get_host_by_name("google.com", AddrType::IPv4));

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -871,6 +871,49 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a request to enable Access Point mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `ap` - Configuration parameters for the access point, including SSID, password, authentication type, etc.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs during packet preparation or sending.
+    pub fn send_enable_access_point(&mut self, ap: &AccessPoint) -> Result<(), Error> {
+        let req = write_en_ap_req(ap)?;
+        self.write_hif_header(
+            HifGroup::Wifi(WifiResponse::Unhandled),
+            WifiRequest::EnableAp,
+            &req,
+            true,
+        )?;
+        self.chip
+            .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
+    /// Sends a request to disable Access Point mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `ap` - Configuration parameters for the access point, including SSID, password, authentication type, etc.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs during packet preparation or sending.
+    pub fn send_disable_access_point(&mut self) -> Result<(), Error> {
+        self.write_hif_header(
+            HifGroup::Wifi(WifiResponse::Unhandled),
+            WifiRequest::DisableAp,
+            &[],
+            false,
+        )?;
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
     pub fn dispatch_events_may_wait<T: EventListener>(
         &mut self,
         listener: &mut T,
@@ -1063,6 +1106,8 @@ impl<X: Xfer> Manager<X> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use constants::ENABLE_AP_PACKET_SIZE;
 
     #[test]
     fn test_hif_header() {
@@ -1298,7 +1343,7 @@ mod tests {
 
         assert_eq!(mgr.send_prng(0x2000_65DC, 16), Ok(()));
 
-        assert_eq!(buff[CMD_OFFSET], 0x1F);
+        assert_eq!(buff[CMD_OFFSET], WifiRequest::GetPrng.into());
 
         let slice = &buff[DATA_OFFSET..DATA_OFFSET + PRNG_PACKET_SIZE];
 
@@ -1310,5 +1355,57 @@ mod tests {
                 0x00, 0x00 // void
             ]
         )
+    }
+
+    #[test]
+    fn test_send_enable_ap() {
+        let mut buff = [0u8; 300];
+        let mut writer = buff.as_mut_slice();
+        let mut mgr = make_manager(&mut writer);
+        let ssid = Ssid::from("ssid").unwrap();
+        let key = WpaKey::from("password").unwrap();
+        let ap = AccessPoint::wpa(&ssid, &key);
+
+        assert_eq!(mgr.send_enable_access_point(&ap), Ok(()));
+
+        assert_eq!(buff[CMD_OFFSET], WifiRequest::EnableAp.into());
+
+        let slice = &buff[DATA_OFFSET..DATA_OFFSET + ENABLE_AP_PACKET_SIZE];
+
+        assert_eq!(
+            slice,
+            &[
+                // Ssid
+                0x73, 0x73, 0x69, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Wifi Channel
+                0x00, // Wep Key Index
+                0x08, // Wep/WPA Key Size
+                // Wep Key
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x02, // Security Type
+                0x00, // SSID Hidden
+                0xC0, 0xA8, 0x01, 0x01, // AP IP
+                // WPA Key
+                0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Padding
+                0x00, 0x00
+            ]
+        )
+    }
+
+    #[test]
+    fn test_send_disable_ap() {
+        let mut buff = [0u8; 73];
+        let mut writer = buff.as_mut_slice();
+        let mut mgr = make_manager(&mut writer);
+
+        assert_eq!(mgr.send_disable_access_point(), Ok(()));
+
+        assert_eq!(buff[CMD_OFFSET], WifiRequest::DisableAp.into());
     }
 }

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -35,6 +35,8 @@ pub const MAX_S802_PASSWORD_LEN: usize = 40;
 pub const MAX_S802_USERNAME_LEN: usize = 20;
 /// Packet size of connect request packet.
 pub(crate) const CONNECT_AP_PACKET_SIZE: usize = 108;
+/// Packet size of enable access point request.
+pub(crate) const ENABLE_AP_PACKET_SIZE: usize = 136;
 
 pub enum Regs {
     SpiConfig = 0xE824,
@@ -197,6 +199,14 @@ pub enum WifiRequest {
     SendWifiPacket = 0x38,   // M2M_WIFI_REQ_SEND_WIFI_PACKET + tstrM2MWifiTxPacketInfo + data
     LsnInt = 0x39,           // M2M_WIFI_REQ_LSN_INT + tstrM2mLsnInt
     Doze = 0x3A,             // M2M_WIFI_REQ_DOZE + tstrM2mSlpReqTime
+    EnableAp = 0x46,         // M2M_WIFI_REQ_ENABLE_AP + tstrM2MAPConfig
+    DisableAp = 0x47,        // M2M_WIFI_REQ_DISABLE_AP
+}
+
+impl From<WifiRequest> for u8 {
+    fn from(val: WifiRequest) -> Self {
+        val as Self
+    }
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -36,6 +36,7 @@ pub(crate) enum WifiModuleState {
     ConnectionFailed,
     Disconnecting,
     Provisioning,
+    AccessPoint,
 }
 
 /// Ping operation results
@@ -289,7 +290,9 @@ impl EventListener for SocketCallbacks {
 
         match self.connection_state.conn_state {
             WifiConnState::Connected => {
-                if self.state != WifiModuleState::Provisioning {
+                if self.state != WifiModuleState::Provisioning
+                    || self.state != WifiModuleState::AccessPoint
+                {
                     self.state = WifiModuleState::ConnectedToAp;
                 }
             }
@@ -300,7 +303,9 @@ impl EventListener for SocketCallbacks {
                         "on_connstate_changed FAILED: {:?} {:?}",
                         self.connection_state.conn_state, self.connection_state.conn_error
                     );
-                } else if self.state != WifiModuleState::Provisioning {
+                } else if self.state != WifiModuleState::Provisioning
+                    || self.state != WifiModuleState::AccessPoint
+                {
                     self.state = WifiModuleState::Unconnected;
                 }
             }


### PR DESCRIPTION
This PR adds the following changes:

1. Add support for Access Point mode.
2. Add relevant test cases.
3. Update the `WifiRequest` enum to include Access Point mode and implement the `From` trait to convert `WifiRequest` to `u8`.
4. Add `AccessPoint` state to `WifiModuleState` enum and fix state matching in the `connect_to_ap_impl` function.
5. Docs in `lib.rs` is updated.