### PR TITLE
Split UDP Multicast into standalone PR

### DIFF
--- a/feather/examples/mdns.rs
+++ b/feather/examples/mdns.rs
@@ -1,0 +1,103 @@
+#![no_main]
+#![no_std]
+
+use bsp::shared::SpiStream;
+use core::net::Ipv4Addr;
+use core::str::FromStr;
+use embedded_nal::{UdpClientStack, UdpFullStack};
+use feather as bsp;
+use feather::hal::ehal::digital::OutputPin;
+use feather::init::init;
+use feather::shared::{create_countdowns, delay_fn};
+use feather::{debug, error, info};
+
+const DEFAULT_TEST_SSID: &str = "network";
+const DEFAULT_TEST_PASSWORD: &str = "password";
+const DEFAULT_TEST_MDNS_PORT: &str = "5353";
+const DEFAULT_TEST_MDNS_IP: &str = "224.0.0.251";
+
+use wincwifi::{
+    Credentials, SocketOptions, Ssid, StackError, UdpSockOpts, WifiChannel, WincClient,
+};
+
+fn program() -> Result<(), StackError> {
+    if let Ok(mut ini) = init() {
+        info!("Hello, Winc Module");
+
+        let mut cnt = create_countdowns(&ini.delay_tick);
+        let red_led = &mut ini.red_led;
+
+        let mut delay_ms = delay_fn(&mut cnt.0);
+
+        let ssid = Ssid::from(option_env!("TEST_SSID").unwrap_or(DEFAULT_TEST_SSID)).unwrap();
+        let password = option_env!("TEST_PASSWORD").unwrap_or(DEFAULT_TEST_PASSWORD);
+        let credentials = Credentials::from_wpa(password)?;
+        info!(
+            "Connecting to network: {} with password: {}",
+            ssid.as_str(),
+            password
+        );
+        let mut stack = WincClient::new(SpiStream::new(ini.cs, ini.spi));
+
+        let mut v = 0;
+        loop {
+            match stack.start_wifi_module() {
+                Ok(_) => break,
+                Err(nb::Error::WouldBlock) => {
+                    debug!("Waiting start .. {}", v);
+                    v += 1;
+                    delay_ms(5)
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        for _ in 0..20 {
+            stack.heartbeat().unwrap();
+            delay_ms(200);
+        }
+
+        info!("Started, connecting to AP ..");
+        nb::block!(stack.connect_to_ap(&ssid, &credentials, WifiChannel::ChannelAll, false))?;
+
+        // Creat the UDP socket
+        let mut socket = stack.socket()?;
+        let test_port = option_env!("TEST_PORT").unwrap_or(DEFAULT_TEST_MDNS_PORT);
+        let test_ip = option_env!("TEST_IP").unwrap_or(DEFAULT_TEST_MDNS_IP);
+        let ip = Ipv4Addr::from_str(test_ip).map_err(|_| StackError::InvalidParameters)?;
+        let port = u16::from_str(test_port).unwrap();
+        // Set the Socket Options to multicast
+        let multicast_opt = SocketOptions::Udp(UdpSockOpts::JoinMulticast(ip));
+        stack.set_socket_option(&mut socket, &multicast_opt)?;
+        // Bind the Socket
+        stack.bind(&mut socket, port)?;
+
+        info!("Server started listening");
+
+        // Wait for query
+        let mut buffer = [0x0u8; 1500];
+        nb::block!(stack.receive(&mut socket, &mut buffer))?;
+
+        info!("Query Received");
+
+        loop {
+            delay_ms(200);
+            red_led.set_high().unwrap();
+            delay_ms(200);
+            red_led.set_low().unwrap();
+            stack.heartbeat().unwrap();
+        }
+    }
+    Ok(())
+}
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    if let Err(err) = program() {
+        error!("Error: {}", err);
+        panic!("Error in main program");
+    } else {
+        info!("Good exit")
+    };
+    loop {}
+}

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -91,7 +91,8 @@ pub use manager::AuthType;
 pub use manager::ConnectionInfo;
 pub use manager::FirmwareInfo;
 pub use manager::{
-    AccessPoint, Credentials, HostName, S8Password, S8Username, Ssid, WifiChannel, WpaKey,
+    AccessPoint, Credentials, HostName, S8Password, S8Username, SocketOptions, Ssid, UdpSockOpts,
+    WifiChannel, WpaKey,
 };
 #[cfg(feature = "wep")]
 pub use manager::{WepKey, WepKeyIndex};

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -782,7 +782,8 @@ impl<X: Xfer> Manager<X> {
     pub fn send_setsockopt(
         &mut self,
         socket: Socket,
-        option: &SocketOptions) -> Result<(), Error> {
+        option: &SocketOptions
+    ) -> Result<(), Error> {
         let req = match option {
             SocketOptions::Udp(opts) => {
                 write_setsockopt_req(socket, (*opts).into(), opts.get_value())?

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -37,6 +37,8 @@ pub const MAX_S802_USERNAME_LEN: usize = 20;
 pub(crate) const CONNECT_AP_PACKET_SIZE: usize = 108;
 /// Packet size of enable access point request.
 pub(crate) const ENABLE_AP_PACKET_SIZE: usize = 136;
+/// Packet size to set socket option request.
+pub(crate) const SET_SOCK_OPTS_PACKET_SIZE: usize = 8;
 
 pub enum Regs {
     SpiConfig = 0xE824,

--- a/winc-rs/src/manager/requests.rs
+++ b/winc-rs/src/manager/requests.rs
@@ -21,7 +21,7 @@ use core::net::{Ipv4Addr, SocketAddrV4};
 
 use super::constants::{
     AuthType, WifiChannel, CONNECT_AP_PACKET_SIZE, ENABLE_AP_PACKET_SIZE,
-    START_PROVISION_PACKET_SIZE,
+    SET_SOCK_OPTS_PACKET_SIZE, START_PROVISION_PACKET_SIZE,
 };
 
 use super::net_types::{Ssid, WepKey};
@@ -233,8 +233,8 @@ pub fn write_setsockopt_req(
     socket: Socket,
     option: u8,
     value: u32,
-) -> Result<[u8; 8], BufferOverflow> {
-    let mut result = [0x0u8; 8];
+) -> Result<[u8; SET_SOCK_OPTS_PACKET_SIZE], BufferOverflow> {
+    let mut result = [0x0u8; SET_SOCK_OPTS_PACKET_SIZE];
     let mut slice = result.as_mut_slice();
     slice.write(&value.to_le_bytes())?;
     slice.write(&[socket.v, option])?;

--- a/winc-rs/src/manager/requests.rs
+++ b/winc-rs/src/manager/requests.rs
@@ -236,7 +236,7 @@ pub fn write_setsockopt_req(
 ) -> Result<[u8; SET_SOCK_OPTS_PACKET_SIZE], BufferOverflow> {
     let mut result = [0x0u8; SET_SOCK_OPTS_PACKET_SIZE];
     let mut slice = result.as_mut_slice();
-    slice.write(&value.to_le_bytes())?;
+    slice.write(&value.to_be_bytes())?;
     slice.write(&[socket.v, option])?;
     slice.write(&socket.s.to_le_bytes())?;
     Ok(result)


### PR DESCRIPTION
Splitting UDP only changes out from #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an mDNS example for the Feather board, demonstrating multicast DNS functionality over WiFi, including LED feedback upon receiving queries.

* **Enhancements**
  * Added support for configuring UDP socket options, including multicast group management.
  * Expanded public APIs to include new socket option types for easier network configuration.
  * Improved socket option request formatting with updated byte order and packet size constants.

* **Bug Fixes**
  * Improved socket option handling for UDP sockets, ensuring correct application of options and error reporting.

* **Documentation**
  * Updated public exports and type definitions for improved clarity in network configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->