### PR TITLE
Add support to access Winc1500 flash memory (Work in Progress)

### DIFF
--- a/winc-rs/Cargo.toml
+++ b/winc-rs/Cargo.toml
@@ -61,6 +61,7 @@ large_rng = [] # This will allocate a 1.6KB buffer for the PRNG upon initializat
 wep = [] # This will enable weak WEP network security.
 irq = [] # Use the IRQ pin on the module.
 experimental-ota = [] # To enable OTA.
+flash-rw = [] # Enable SPI Flash Read/Write access.
 
 # Todo: add feature flags to save binary space
 # - TCP

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -6,6 +6,8 @@ use crate::transfer::Xfer;
 mod dns;
 #[cfg(feature = "experimental-ota")]
 mod ota;
+//#[cfg(feature = "flash-rw")]
+mod flash;
 mod prng;
 mod tcp_stack;
 mod udp_stack;

--- a/winc-rs/src/client/flash.rs
+++ b/winc-rs/src/client/flash.rs
@@ -1,0 +1,217 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{StackError, WincClient, Xfer};
+use crate::error;
+use crate::manager::FLASH_PAGE_SIZE;
+
+/// Block Size of flash memory.
+const FLASH_BLOCK_SIZE: usize = 32 * 1024;
+
+impl<X: Xfer> WincClient<'_, X> {
+    pub fn enable_download_mode() {
+        
+    }
+
+    /// Enables or disables read/write access to the flash.
+    ///
+    /// # Arguments
+    ///
+    /// * `enable` – `true` to enable access, `false` to disable.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – Flash access was successfully enabled or disabled.
+    /// * `StackError` – If an error occurs while enabling or disabling access to the flash.
+    pub fn set_flash_access(&mut self, enable: bool) -> Result<(), StackError> {
+        // todo! add check for chip id.
+        // enable pinmux on flash.
+        self.manager
+            .send_flash_pin_mux(true)
+            .map_err(StackError::WincWifiFail)?;
+
+        if enable {
+            // exit the low power mode.
+            self.manager
+                .send_flash_low_power_mode(false)
+                .map_err(StackError::WincWifiFail)?;
+        } else {
+            // enter low power mode.
+            self.manager
+                .send_flash_low_power_mode(true)
+                .map_err(StackError::WincWifiFail)?;
+        }
+
+        // disable pinmux on flash.
+        self.manager
+            .send_flash_pin_mux(false)
+            .map_err(StackError::WincWifiFail)
+    }
+
+    /// Reads data from flash memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` – The flash memory address to read from.
+    /// * `buffer` – A mutable buffer where the read data will be stored.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – Data was successfully read from flash memory.
+    /// * `StackError` – If an error occurs while reading data from the flash.
+    pub fn flash_read(&mut self, addr: u32, buffer: &mut [u8]) -> Result<(), StackError> {
+        let mut offset: usize = 0;
+        let mut flash_addr = addr;
+
+        loop {
+            let to_recv = (buffer[offset..]).len().min(FLASH_BLOCK_SIZE);
+            // read the data
+            self.manager
+                .send_flash_read(flash_addr, &mut buffer[offset..to_recv])
+                .map_err(StackError::WincWifiFail)?;
+            offset += to_recv;
+            // check if all data is read.
+            if offset >= buffer.len() {
+                return Ok(());
+            } else {
+                flash_addr += to_recv as u32;
+            }
+        }
+    }
+
+    /// Writes data to flash memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` – The flash memory address to start writing at.
+    /// * `data` – The data to be written.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – Data was successfully written to flash memory.
+    /// * `StackError` – If an error occurs while writing data to the flash.
+    pub fn flash_write(&mut self, addr: u32, data: &[u8]) -> Result<(), StackError> {
+        if data.is_empty() {
+            return Err(StackError::InvalidParameters);
+        }
+
+        let page_offset = addr as usize % FLASH_PAGE_SIZE; // offset on current page of flash memory.
+        let mut offset: usize = 0; // buffer offset.
+        let mut flash_addr = addr; // current flash memory address.
+
+        if page_offset > 0 {
+            let word_size = FLASH_PAGE_SIZE - page_offset;
+            let valid_size = data.len().min(word_size);
+            self.manager
+                .send_flash_write(flash_addr, &data[..valid_size])
+                .map_err(StackError::WincWifiFail)?;
+            // check if all bytes are written.
+            if data.len() <= word_size {
+                return Ok(());
+            }
+            // Increament the buffer and flash address by bytes written.
+            offset += word_size;
+            flash_addr += word_size as u32;
+        }
+
+        while offset < data.len() {
+            let word_size = data[offset..].len().min(FLASH_PAGE_SIZE);
+
+            self.manager
+                .send_flash_write(flash_addr, &data[offset..word_size])
+                .map_err(StackError::WincWifiFail)?;
+
+            // Increament the buffer and flash address by bytes written.
+            offset += word_size;
+            flash_addr += word_size as u32;
+        }
+
+        Ok(())
+    }
+
+    /// Erases a region of flash memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` – The address in flash memory to erase.
+    /// * `size` – The size of the region to erase, in bytes. Must be aligned to the flash sector or block size.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – Flash memory was successfully erased.
+    /// * `StackError` – If an error occurs while erasing the flash memory.
+    pub fn flash_erase(&mut self, addr: u32, size: u32) -> Result<(), StackError> {
+        let mut flash_addr: u32 = addr;
+        let mut retires: u8 = 3;
+
+        loop {
+            self.manager
+                .send_flash_write_access(true)
+                .map_err(StackError::WincWifiFail)?;
+            let _ = self
+                .manager
+                .send_flash_read_status_register()
+                .map_err(StackError::WincWifiFail)?;
+            self.manager
+                .send_flash_erase_sector(flash_addr + 10)
+                .map_err(StackError::WincWifiFail)?;
+            let mut val = self
+                .manager
+                .send_flash_read_status_register()
+                .map_err(StackError::WincWifiFail)?;
+
+            while (val & 0x01) != 0 {
+                if retires == 0 {
+                    error!(
+                        "Erasing flash sector failed due to invalid flash status register value."
+                    );
+                    return Err(StackError::GeneralTimeout);
+                }
+                retires -= 1;
+                val = self
+                    .manager
+                    .send_flash_read_status_register()
+                    .map_err(StackError::WincWifiFail)?;
+            }
+
+            if flash_addr < (addr + size) {
+                flash_addr += (16 * FLASH_PAGE_SIZE) as u32;
+            } else {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Returns the size of the flash memory.
+    ///
+    /// # Returns
+    ///
+    /// * `u32` – The size of the flash memory in bytes.
+    /// * `StackError` – If an error occurs while retrieving the size of the flash memory.
+    pub fn flash_get_size(&mut self) -> Result<u32, StackError> {
+        let id = self
+            .manager
+            .send_flash_read_id()
+            .map_err(StackError::WincWifiFail)?;
+
+        if id == 0xffffffff {
+            error!("Unable to read the flash ID.");
+            return Err(StackError::Unexpected);
+        }
+
+        let flash_size = 1u32 << (((id >> 16) & 0xFF) - 0x11);
+
+        Ok(flash_size)
+    }
+}

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -25,7 +25,7 @@ mod event_listener;
 mod net_types;
 mod requests;
 mod responses;
-use crate::{debug, trace};
+use crate::{debug, trace, error};
 
 use chip_access::ChipAccess;
 #[cfg(feature = "experimental-ota")]
@@ -126,6 +126,9 @@ const ETHERNET_HEADER_LENGTH: usize = 14;
 const ETHERNET_HEADER_OFFSET: usize = 34;
 const IP_PACKET_OFFSET: usize = ETHERNET_HEADER_LENGTH + ETHERNET_HEADER_OFFSET; // - HIF_HEADER_OFFSET;
 const HIF_SEND_RETRIES: usize = 1000;
+const FLASH_REG_READ_RETRIES: usize = 10; // Total wait time: 1 second (10 retries with a 100 ms backoff delay).
+const FLASH_REG_READ_DELAY_US: u32 = 1000 * 100; // 100 ms backoff delay in microseconds.
+const FLASH_DUMMY_VALUE: u32 = 0x1084;
 
 // todo this needs to be used
 #[allow(dead_code)]
@@ -917,6 +920,343 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    //#[cfg(feature = "flash-rw")]
+    /// Checks the flash data transfer register.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the flash transfer is complete.
+    /// * `Error` - If an error occurs while reading the register or the process times out.
+    fn check_flash_tx_complete(&mut self) -> Result<(), Error> {
+        let mut retries = FLASH_REG_READ_RETRIES;
+        let mut res: u32;
+
+        loop {
+            res = self.chip.single_reg_read(Regs::FlashTransferDone.into())?;
+
+            if res != 1 && retries == 0 {
+                error!("Reading flash transfer complete register timedout.");
+                return Err(Error::Failed);
+            } else if res == 1 {
+                break;
+            } else {
+                retries -= 1;
+                self.chip.delay_us(FLASH_REG_READ_DELAY_US);
+            }
+        }
+
+        Ok(())
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to write data (less than a page size) from Cortus memory to flash.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `mem_addr` – The memory address of the Cortus processor. It must be set to its AHB access address.
+    /// * `flash_addr` – The flash address where data will be written.
+    /// * `data_size` – The size of the data to write.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - The data was successfully written to flash.
+    /// * `Error` - If an error occurs while writing the data from Cortus memory to flash.
+    fn send_flash_page_program(&mut self, mem_addr: u32, flash_addr: u32, data_size: u8) -> Result<(), Error> {
+        let cmd = {
+            let b = flash_addr.to_be_bytes();
+            [0x02, b[1], b[2], b[3]]
+        };
+
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x0F)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), mem_addr)?;
+
+        let size = ((data_size as usize & 0xfffff) << 8) | 0x84;
+
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), size as u32)?;
+
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Reads the Flash Status Register.
+    ///
+    /// # Returns
+    ///
+    /// * `u8` - The value of the status register.
+    /// * `Error` - If an error occurs while reading the status register.
+    pub(crate) fn read_flash_status_register(&mut self) -> Result<u8, Error> {
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 4)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 5)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 1)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), FLASH_DUMMY_VALUE)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), FLASH_DUMMY_VALUE)?;
+
+        // read transfer complete register.
+        self.check_flash_tx_complete()?;
+        
+        let res = self.chip.single_reg_read(0x1084)?; // dummy register
+        Ok((res & 0xff) as u8)
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to load data from flash into Cortus processor memory.
+    /// 
+    /// # Arguments
+    ///
+    /// * `flash_addr` – The flash address to load data from.
+    /// * `data_size` – The size of the data to load.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Data is successfully loaded into Cortus processor memory.
+    /// * `Error` - If an error occurs while loading the flash data into Cortus memory.
+    fn send_flash_load_data_to_cortus_memory(&mut self, flash_addr: u32, data_size: usize) -> Result<(), Error> {
+        let cmd = {
+            let b = flash_addr.to_be_bytes();
+            [0x0b, b[1], b[2], b[3]]
+        };
+
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), data_size as u32)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
+        self.chip.single_reg_write(Regs::FlashBuffer2.into(), 0xA5)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x1F)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), Regs::FlashSharedMemory.into())?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x85)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to erase a flash sector (4KB).
+    /// 
+    /// # Arguments
+    /// 
+    /// * `flash_addr` - The flash address of the sector to erase.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - The flash sector was successfully erased.
+    /// * `Error` - If an error occurs while erasing the flash sector.
+    pub(crate) fn send_flash_erase_sector(&mut self, flash_addr: u32) -> Result<(), Error> {
+        let cmd = {
+            let b = flash_addr.to_be_bytes();
+            [0x20, b[1], b[2], b[3]]
+        };
+
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x0F)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x84)?;
+
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to enable writing to flash.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Writing to flash was successfully enabled.
+    /// * `Error` - If an error occurs while sending the command to enable writing to flash.
+    pub(crate) fn send_flash_write_enable(&mut self) -> Result<(), Error> {
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x06)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    pub(crate) fn send_flash_set_write_access(&mut self, enable: bool) -> Result<(), Error> {
+
+        let val = if enable {
+            0x06
+        } else {
+            
+        }
+
+
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x06)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+        
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to disable writing to flash.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Writing to flash was successfully disabled.
+    /// * `Error` - If an error occurs while sending the command to disable writing to flash.
+    pub(crate) fn send_flash_write_disable(&mut self) -> Result<(), Error> {
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x04)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to write data to a flash memory.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `flash_addr` – The address in flash memory where the data will be written.
+    /// * `data` – The data to write. Must not exceed the flash page size (256 bytes).
+    ///
+    /// # Returns
+    ///
+    /// * `()` - The data was successfully written to flash memory.
+    /// * `Error` - If an error occurs while writing the data to flash.
+    pub(crate) fn send_flash_write(&mut self, flash_addr: u32, data: &[u8]) -> Result<(), Error> {
+
+        if data.len() > 256 {
+            error!("Data should not be greater than the page size, which is 256 bytes.");
+            return Err(Error::Failed);
+        }
+        // enable flash writing
+        self.send_flash_write_enable()?;
+        // use shared memory
+        self.chip.dma_block_write(Regs::FlashSharedMemory.into(), data)?;
+        // set flash address
+        self.send_flash_page_program(Regs::FlashSharedMemory.into(), flash_addr, data.len() as u8)?;
+        // read status register
+        let mut retries = FLASH_REG_READ_RETRIES;
+        let mut res: u8;
+
+        loop {
+            res = self.read_flash_status_register()?;
+
+            if (res & 0x01) != 0 && retries == 0 {
+                return Err(Error::Failed);
+            } else if (res & 0x01) == 0 {
+                break;
+            } else {
+                retries -= 1;
+                self.chip.delay_us(FLASH_REG_READ_DELAY_US);
+            }
+        }
+
+        // disable writing to flash
+        self.send_flash_write_disable()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to read the flash ID.
+    ///
+    /// # Returns
+    ///
+    /// * `u32` - The flash ID.
+    /// * `Error` - If an error occurs while reading the flash ID.
+    pub(crate) fn send_flash_read_id(&mut self) -> Result<u32, Error> {
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x04)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x9F)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), FLASH_DUMMY_VALUE)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()?;
+
+        Ok(self.chip.single_reg_read(FLASH_DUMMY_VALUE)?)
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to the flash to enter low power mode.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - The flash successfully entered low power mode.
+    /// * `Error` - If an error occurs while attempting to enter low power mode.
+    pub(crate) fn send_flash_enter_low_power_mode(&mut self) -> Result<(), Error> {
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0xB9)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to the flash to exit low power mode.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - The flash successfully exited low power mode.
+    /// * `Error` - If an error occurs while attempting to exit low power mode.
+    pub(crate) fn send_flash_leave_low_power_mode(&mut self) -> Result<(), Error> {
+        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0xAB)?;
+        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
+        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        // read transfer complete register.
+        self.check_flash_tx_complete()
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to enable flash pinmux.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Pinmuxing is enabled on flash.
+    /// * `Error` - If an error occurs while enabling the pinmux on the flash.
+    pub(crate) fn send_flash_enable_pin_mux(&mut self) -> Result<(), Error> {
+        let mut val = self.chip.single_reg_read(Regs::FlashPinMux.into())?;
+
+        val &= !((0x7777) << 12);
+        val |= (0x1111) << 12;
+
+        self.chip.single_reg_write(Regs::FlashPinMux.into(), val)
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to disable flash pinmux.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Pinmuxing is disabled on flash.
+    /// * `Error` - If an error occurs while disabling the pinmux on the flash.
+    pub(crate) fn send_flash_disable_pin_mux(&mut self) -> Result<(), Error> {
+        let mut val = self.chip.single_reg_read(Regs::FlashPinMux.into())?;
+
+        val &= !((0x7777) << 12);
+        val |= (0x0010) << 12;
+
+        self.chip.single_reg_write(Regs::FlashPinMux.into(), val)
+    }
+
+    //#[cfg(feature = "flash-rw")]
+    /// Sends a command to read data from flash memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `flash_addr` – The address in flash memory to read from.
+    /// * `buffer` – A mutable buffer where the read data will be stored.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – Data was successfully read from flash memory.
+    /// * `Error` – If an error occurs while reading data from the flash.
+    pub(crate) fn send_flash_read(&mut self, flash_addr: u32, buffer: &mut [u8]) -> Result<(), Error> {
+        // load data to shared memory between flash and cortus processor.
+        self.send_flash_load_data_to_cortus_memory(flash_addr, buffer.len())?;
+        // read the data from th shared from memory
+        self.chip.dma_block_read(Regs::FlashSharedMemory.into(), buffer)
+    }
     // #endregion write
 }
 

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -25,7 +25,7 @@ mod event_listener;
 mod net_types;
 mod requests;
 mod responses;
-use crate::{debug, trace, error};
+use crate::{debug, error, trace};
 
 use chip_access::ChipAccess;
 #[cfg(feature = "experimental-ota")]
@@ -37,7 +37,7 @@ use constants::{IpCode, Regs, WifiRequest, WifiResponse};
 
 #[cfg(feature = "experimental-ota")]
 pub(crate) use constants::{OtaRequest, OtaResponse, OtaUpdateStatus};
-pub(crate) use constants::{PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
+pub(crate) use constants::{FLASH_PAGE_SIZE, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
 
 pub use net_types::{
     AccessPoint, Credentials, HostName, ProvisioningInfo, S8Password, S8Username, SocketOptions,
@@ -929,20 +929,18 @@ impl<X: Xfer> Manager<X> {
     /// * `Error` - If an error occurs while reading the register or the process times out.
     fn check_flash_tx_complete(&mut self) -> Result<(), Error> {
         let mut retries = FLASH_REG_READ_RETRIES;
-        let mut res: u32;
+        let mut res = self.chip.single_reg_read(Regs::FlashTransferDone.into())?;
 
-        loop {
-            res = self.chip.single_reg_read(Regs::FlashTransferDone.into())?;
-
-            if res != 1 && retries == 0 {
-                error!("Reading flash transfer complete register timedout.");
+        while res != 1 {
+            if retries == 0 {
+                error!("Reading flash transfer complete register timed out.");
                 return Err(Error::Failed);
-            } else if res == 1 {
-                break;
-            } else {
-                retries -= 1;
-                self.chip.delay_us(FLASH_REG_READ_DELAY_US);
             }
+
+            retries -= 1;
+            self.chip.delay_us(FLASH_REG_READ_DELAY_US);
+
+            res = self.chip.single_reg_read(Regs::FlashTransferDone.into())?;
         }
 
         Ok(())
@@ -950,10 +948,9 @@ impl<X: Xfer> Manager<X> {
 
     //#[cfg(feature = "flash-rw")]
     /// Sends a command to write data (less than a page size) from Cortus memory to flash.
-    /// 
+    ///
     /// # Arguments
-    /// 
-    /// * `mem_addr` – The memory address of the Cortus processor. It must be set to its AHB access address.
+    ///
     /// * `flash_addr` – The flash address where data will be written.
     /// * `data_size` – The size of the data to write.
     ///
@@ -961,49 +958,59 @@ impl<X: Xfer> Manager<X> {
     ///
     /// * `()` - The data was successfully written to flash.
     /// * `Error` - If an error occurs while writing the data from Cortus memory to flash.
-    fn send_flash_page_program(&mut self, mem_addr: u32, flash_addr: u32, data_size: u8) -> Result<(), Error> {
+    fn send_flash_write_page(&mut self, flash_addr: u32, data_size: u8) -> Result<(), Error> {
         let cmd = {
             let b = flash_addr.to_be_bytes();
             [0x02, b[1], b[2], b[3]]
         };
 
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x0F)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), mem_addr)?;
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip
+            .single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x0F)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), Regs::FlashSharedMemory.into())?;
 
-        let size = ((data_size as usize & 0xfffff) << 8) | 0x84;
+        let size = 4 | (1 << 7) | ((data_size as usize & 0xfffff) << 8);
 
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), size as u32)?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), size as u32)?;
 
         // read transfer complete register.
         self.check_flash_tx_complete()
     }
 
     //#[cfg(feature = "flash-rw")]
-    /// Reads the Flash Status Register.
+    /// Sends a command to read the flash status register.
     ///
     /// # Returns
     ///
-    /// * `u8` - The value of the status register.
-    /// * `Error` - If an error occurs while reading the status register.
-    pub(crate) fn read_flash_status_register(&mut self) -> Result<u8, Error> {
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 4)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 5)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 1)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), FLASH_DUMMY_VALUE)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), FLASH_DUMMY_VALUE)?;
+    /// * `u8` – The value of the status register.
+    /// * `Error` – If an error occurs while reading the status register.
+    pub(crate) fn send_flash_read_status_register(&mut self) -> Result<u8, Error> {
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), 0x04)?;
+        self.chip
+            .single_reg_write(Regs::FlashBuffer1.into(), 0x05)?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), FLASH_DUMMY_VALUE)?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
 
         // read transfer complete register.
         self.check_flash_tx_complete()?;
-        
-        let res = self.chip.single_reg_read(0x1084)?; // dummy register
+
+        let res = self.chip.single_reg_read(FLASH_DUMMY_VALUE)?;
         Ok((res & 0xff) as u8)
     }
 
     //#[cfg(feature = "flash-rw")]
     /// Sends a command to load data from flash into Cortus processor memory.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `flash_addr` – The flash address to load data from.
@@ -1013,27 +1020,37 @@ impl<X: Xfer> Manager<X> {
     ///
     /// * `()` - Data is successfully loaded into Cortus processor memory.
     /// * `Error` - If an error occurs while loading the flash data into Cortus memory.
-    fn send_flash_load_data_to_cortus_memory(&mut self, flash_addr: u32, data_size: usize) -> Result<(), Error> {
+    fn send_flash_load_data_to_cortus_memory(
+        &mut self,
+        flash_addr: u32,
+        data_size: usize,
+    ) -> Result<(), Error> {
         let cmd = {
             let b = flash_addr.to_be_bytes();
             [0x0b, b[1], b[2], b[3]]
         };
 
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), data_size as u32)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
-        self.chip.single_reg_write(Regs::FlashBuffer2.into(), 0xA5)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x1F)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), Regs::FlashSharedMemory.into())?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x85)?;
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), data_size as u32)?;
+        self.chip
+            .single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
+        self.chip
+            .single_reg_write(Regs::FlashBuffer2.into(), 0xA5)?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x1F)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), Regs::FlashSharedMemory.into())?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), 0x85)?;
         // read transfer complete register.
         self.check_flash_tx_complete()
     }
 
     //#[cfg(feature = "flash-rw")]
     /// Sends a command to erase a flash sector (4KB).
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `flash_addr` - The flash address of the sector to erase.
     ///
     /// # Returns
@@ -1046,74 +1063,52 @@ impl<X: Xfer> Manager<X> {
             [0x20, b[1], b[2], b[3]]
         };
 
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x0F)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x84)?;
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip
+            .single_reg_write(Regs::FlashBuffer1.into(), u32::from_le_bytes(cmd))?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x0F)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), 0x84)?;
 
         // read transfer complete register.
         self.check_flash_tx_complete()
     }
 
     //#[cfg(feature = "flash-rw")]
-    /// Sends a command to enable writing to flash.
+    /// Sends a command to enable or disable write access to the flash.
+    ///
+    /// # Arguments
+    ///
+    /// * `enable` – `true` to enable write access; `false` to disable it.
     ///
     /// # Returns
     ///
-    /// * `()` - Writing to flash was successfully enabled.
-    /// * `Error` - If an error occurs while sending the command to enable writing to flash.
-    pub(crate) fn send_flash_write_enable(&mut self) -> Result<(), Error> {
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x06)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
-        // read transfer complete register.
-        self.check_flash_tx_complete()
-    }
-
-    pub(crate) fn send_flash_set_write_access(&mut self, enable: bool) -> Result<(), Error> {
-
-        let val = if enable {
-            0x06
-        } else {
-            
-        }
-
-
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x06)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
-        // read transfer complete register.
-        self.check_flash_tx_complete()
-        
-    }
-
-    //#[cfg(feature = "flash-rw")]
-    /// Sends a command to disable writing to flash.
-    ///
-    /// # Returns
-    ///
-    /// * `()` - Writing to flash was successfully disabled.
-    /// * `Error` - If an error occurs while sending the command to disable writing to flash.
-    pub(crate) fn send_flash_write_disable(&mut self) -> Result<(), Error> {
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x04)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+    /// * `()` – Write access to the flash was successfully enabled or disabled.
+    /// * `Error` – If an error occurs while sending the command to change write access.
+    pub(crate) fn send_flash_write_access(&mut self, enable: bool) -> Result<(), Error> {
+        let val = if enable { 0x06 } else { 0x04 };
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), val)?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), 0x00)?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
         // read transfer complete register.
         self.check_flash_tx_complete()
     }
 
     //#[cfg(feature = "flash-rw")]
     /// Sends a command to write data to a flash memory.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `flash_addr` – The address in flash memory where the data will be written.
     /// * `data` – The data to write. Must not exceed the flash page size (256 bytes).
     ///
@@ -1122,36 +1117,38 @@ impl<X: Xfer> Manager<X> {
     /// * `()` - The data was successfully written to flash memory.
     /// * `Error` - If an error occurs while writing the data to flash.
     pub(crate) fn send_flash_write(&mut self, flash_addr: u32, data: &[u8]) -> Result<(), Error> {
-
-        if data.len() > 256 {
+        if data.is_empty() {
+            error!("Invalid data buffer");
+            return Err(Error::BufferError);
+        }
+        if data.len() > FLASH_PAGE_SIZE {
             error!("Data should not be greater than the page size, which is 256 bytes.");
             return Err(Error::Failed);
         }
         // enable flash writing
-        self.send_flash_write_enable()?;
+        self.send_flash_write_access(true)?;
         // use shared memory
-        self.chip.dma_block_write(Regs::FlashSharedMemory.into(), data)?;
+        self.chip
+            .dma_block_write(Regs::FlashSharedMemory.into(), data)?;
         // set flash address
-        self.send_flash_page_program(Regs::FlashSharedMemory.into(), flash_addr, data.len() as u8)?;
+        self.send_flash_write_page(flash_addr, data.len() as u8)?;
         // read status register
         let mut retries = FLASH_REG_READ_RETRIES;
-        let mut res: u8;
+        let mut res = self.send_flash_read_status_register()?;
 
-        loop {
-            res = self.read_flash_status_register()?;
-
-            if (res & 0x01) != 0 && retries == 0 {
+        while (res & 0x01) != 0 {
+            if retries == 0 {
                 return Err(Error::Failed);
-            } else if (res & 0x01) == 0 {
-                break;
-            } else {
-                retries -= 1;
-                self.chip.delay_us(FLASH_REG_READ_DELAY_US);
             }
+
+            retries -= 1;
+            self.chip.delay_us(FLASH_REG_READ_DELAY_US);
+
+            res = self.send_flash_read_status_register()?;
         }
 
         // disable writing to flash
-        self.send_flash_write_disable()
+        self.send_flash_write_access(false)
     }
 
     //#[cfg(feature = "flash-rw")]
@@ -1162,79 +1159,71 @@ impl<X: Xfer> Manager<X> {
     /// * `u32` - The flash ID.
     /// * `Error` - If an error occurs while reading the flash ID.
     pub(crate) fn send_flash_read_id(&mut self) -> Result<u32, Error> {
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x04)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0x9F)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), FLASH_DUMMY_VALUE)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), 0x04)?;
+        self.chip
+            .single_reg_write(Regs::FlashBuffer1.into(), 0x9F)?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), FLASH_DUMMY_VALUE)?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
         // read transfer complete register.
         self.check_flash_tx_complete()?;
 
-        Ok(self.chip.single_reg_read(FLASH_DUMMY_VALUE)?)
+        let value = self.chip.single_reg_read(FLASH_DUMMY_VALUE)?;
+
+        Ok(value)
     }
 
     //#[cfg(feature = "flash-rw")]
-    /// Sends a command to the flash to enter low power mode.
+    /// Sends a command to the flash to enter or exit low power mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `enable` – `true` to enter low power mode; `false` to exit it.
     ///
     /// # Returns
     ///
-    /// * `()` - The flash successfully entered low power mode.
-    /// * `Error` - If an error occurs while attempting to enter low power mode.
-    pub(crate) fn send_flash_enter_low_power_mode(&mut self) -> Result<(), Error> {
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0xB9)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
+    /// * `()` – The flash successfully entered or exited low power mode.
+    /// * `Error` – If an error occurs while attempting to change the flash power mode.
+    pub(crate) fn send_flash_low_power_mode(&mut self, enable: bool) -> Result<(), Error> {
+        let val: u32 = if enable { 0xB9 } else { 0xAB };
+        self.chip
+            .single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
+        self.chip.single_reg_write(Regs::FlashBuffer1.into(), val)?;
+        self.chip
+            .single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
+        self.chip
+            .single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
+        self.chip
+            .single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
         // read transfer complete register.
         self.check_flash_tx_complete()
     }
 
     //#[cfg(feature = "flash-rw")]
-    /// Sends a command to the flash to exit low power mode.
+    /// Sends a command to enable or disable flash pinmux.
+    ///
+    /// # Arguments
+    ///
+    /// * `enable` – `true` to enable pinmux; `false` to disable it.
     ///
     /// # Returns
     ///
-    /// * `()` - The flash successfully exited low power mode.
-    /// * `Error` - If an error occurs while attempting to exit low power mode.
-    pub(crate) fn send_flash_leave_low_power_mode(&mut self) -> Result<(), Error> {
-        self.chip.single_reg_write(Regs::FlashDataCount.into(), 0x00)?;
-        self.chip.single_reg_write(Regs::FlashBuffer1.into(), 0xAB)?;
-        self.chip.single_reg_write(Regs::FlashBufferDirectory.into(), 0x01)?;
-        self.chip.single_reg_write(Regs::FlashDmaAddress.into(), 0)?;
-        self.chip.single_reg_write(Regs::FlashCommmandCount.into(), 0x81)?;
-        // read transfer complete register.
-        self.check_flash_tx_complete()
-    }
-
-    //#[cfg(feature = "flash-rw")]
-    /// Sends a command to enable flash pinmux.
-    ///
-    /// # Returns
-    ///
-    /// * `()` - Pinmuxing is enabled on flash.
-    /// * `Error` - If an error occurs while enabling the pinmux on the flash.
-    pub(crate) fn send_flash_enable_pin_mux(&mut self) -> Result<(), Error> {
+    /// * `()` – Pinmux was successfully enabled or disabled on the flash.
+    /// * `Error` – If an error occurs while enabling or disabling the flash pinmux.
+    pub(crate) fn send_flash_pin_mux(&mut self, enable: bool) -> Result<(), Error> {
         let mut val = self.chip.single_reg_read(Regs::FlashPinMux.into())?;
 
-        val &= !((0x7777) << 12);
-        val |= (0x1111) << 12;
+        val &= !((0x7777) << 12); // GPIO15/16/17/18
 
-        self.chip.single_reg_write(Regs::FlashPinMux.into(), val)
-    }
-
-    //#[cfg(feature = "flash-rw")]
-    /// Sends a command to disable flash pinmux.
-    ///
-    /// # Returns
-    ///
-    /// * `()` - Pinmuxing is disabled on flash.
-    /// * `Error` - If an error occurs while disabling the pinmux on the flash.
-    pub(crate) fn send_flash_disable_pin_mux(&mut self) -> Result<(), Error> {
-        let mut val = self.chip.single_reg_read(Regs::FlashPinMux.into())?;
-
-        val &= !((0x7777) << 12);
-        val |= (0x0010) << 12;
+        val |= if enable {
+            (0x1111) << 12
+        } else {
+            (0x0010) << 12
+        };
 
         self.chip.single_reg_write(Regs::FlashPinMux.into(), val)
     }
@@ -1251,11 +1240,19 @@ impl<X: Xfer> Manager<X> {
     ///
     /// * `()` – Data was successfully read from flash memory.
     /// * `Error` – If an error occurs while reading data from the flash.
-    pub(crate) fn send_flash_read(&mut self, flash_addr: u32, buffer: &mut [u8]) -> Result<(), Error> {
+    pub(crate) fn send_flash_read(
+        &mut self,
+        flash_addr: u32,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Err(Error::BufferError);
+        }
         // load data to shared memory between flash and cortus processor.
         self.send_flash_load_data_to_cortus_memory(flash_addr, buffer.len())?;
         // read the data from th shared from memory
-        self.chip.dma_block_read(Regs::FlashSharedMemory.into(), buffer)
+        self.chip
+            .dma_block_read(Regs::FlashSharedMemory.into(), buffer)
     }
     // #endregion write
 }

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -50,6 +50,8 @@ pub(crate) const PRNG_PACKET_SIZE: usize = 8;
 pub(crate) const PRNG_DATA_LENGTH: usize = 1600 - 4 - PRNG_PACKET_SIZE;
 #[cfg(not(feature = "large_rng"))]
 pub(crate) const PRNG_DATA_LENGTH: usize = 32;
+/// Page size of Flash memory.
+pub(crate) const FLASH_PAGE_SIZE: usize = 256;
 
 pub enum Regs {
     SpiConfig = 0xE824,
@@ -69,6 +71,28 @@ pub enum Regs {
     WifiHostRcvCtrl2 = 0x1078,
     WifiHostRcvCtrl3 = 0x106c,
     WifiHostRcvCtrl4 = 0x150400,
+    //#[cfg(feature = "flash-rw")]
+    FlashCommmandCount = 0x10204,
+    //#[cfg(feature = "flash-rw")]
+    FlashDataCount = 0x10208,
+    //#[cfg(feature = "flash-rw")]
+    FlashBuffer1 = 0x1020c,
+    //#[cfg(feature = "flash-rw")]
+    FlashBuffer2 = 0x10210,
+    //#[cfg(feature = "flash-rw")]
+    FlashBufferDirectory = 0x10214,
+    //#[cfg(feature = "flash-rw")]
+    FlashTransferDone = 0x10218,
+    //#[cfg(feature = "flash-rw")]
+    FlashDmaAddress = 0x1021c,
+    //#[cfg(feature = "flash-rw")]
+    FlashMsbControl = 0x10220,
+    //#[cfg(feature = "flash-rw")]
+    FlashTransmitControl = 0x10224,
+    //#[cfg(feature = "flash-rw")]
+    FlashSharedMemory = 0xd0000,
+    //#[cfg(feature = "flash-rw")]
+    FlashPinMux = 0x1410,
 }
 
 impl From<Regs> for u32 {


### PR DESCRIPTION
This PR adds API's to access the flash memory of winc1500 chip.
1. Flash access apis (Read, Write, Get ID, Erase) are added. 

Missing:
1. Support to boot module in download mode.
2. Unit Test cases.
3. Serial Updater Example.

**Changes should not be tested on hardware.**