### PR TITLE
Disabled the USB feature by default.

### DIFF
--- a/feather/Cargo.toml
+++ b/feather/Cargo.toml
@@ -47,7 +47,7 @@ required-features = ["telnet"]
 
 [features]
 # Do most of development and testing with IRQ enabled
-default = ["irq","usb","defmt"] # Use defmt by default, or switch to "log" for USB logging
+default = ["irq", "defmt"] # Use defmt by default, or switch to "log" for USB logging
 iperf3 = ["demos/iperf3"]
 oled = ["dep:ssd1306"]
 telnet = ["demos/telnet"]


### PR DESCRIPTION
This PR removes the USB as default feature to reduce the binary size #103 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default build options to produce a leaner baseline configuration.
  * USB-related functionality is no longer included by default; enable it explicitly when needed.
  * This change may reduce compile times and binary size for typical builds.
  * No changes to runtime behavior for users who do not rely on USB features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->