### PR TITLE
Add data packet size and offset to HIF header function

### DIFF
--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -1732,4 +1732,19 @@ mod tests {
 
         assert_eq!(buff[CMD_OFFSET], WifiRequest::DisableAp.into());
     }
+
+    #[test]
+    fn test_hif_header_exceeded_len() {
+        let mut buff = [0u8; 73];
+        let mut writer = buff.as_mut_slice();
+        let mut mgr = make_manager(&mut writer);
+
+        let req = HifRequest::Wifi(WifiRequest::Connect);
+        let payload = [0u8; 65535];
+        let data_pkt = Some((65535, 128));
+
+        let res = mgr.write_hif_header_impl(req, &payload, true, data_pkt);
+
+        assert_eq!(res, Err(Error::BufferError));
+    }
 }


### PR DESCRIPTION
This PR updates the HIF header writer function to include the data packet size and offset. These changes are required to support sending SSL certificates to the module."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Streamlined request handling and added support for optional data offsets in header preparation for more flexible transfers.
  - Improved header and payload length calculations for more accurate, reliable communication.

- Bug Fixes
  - Added bounds checking to prevent oversized headers, returning a clear error when limits are exceeded.

- Tests
  - Added tests covering the oversized-header/error path.

- Documentation
  - Expanded internal docs clarifying header/write behaviors and arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->