### PR TITLE
Add support for SSL operations

### DIFF
--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -9,6 +9,7 @@ mod flash;
 #[cfg(feature = "experimental-ota")]
 mod ota;
 mod prng;
+mod ssl;
 mod tcp_stack;
 mod udp_stack;
 mod wifi_module;

--- a/winc-rs/src/client/ssl.rs
+++ b/winc-rs/src/client/ssl.rs
@@ -2,7 +2,7 @@ use super::StackError;
 use super::WincClient;
 use super::Xfer;
 
-use crate::manager::{SslCertExpiryOpt, EccReqInfo};
+use crate::manager::{EccReqInfo, SslCertExpiryOpt};
 
 impl<X: Xfer> WincClient<'_, X> {
     /// Configure the SSL certificate expiry option.
@@ -33,7 +33,11 @@ impl<X: Xfer> WincClient<'_, X> {
         Ok(self.manager.send_ssl_cert(cert)?)
     }
 
-    pub fn ssl_handshake_resp(&mut self, ecc_req: &EccReqInfo, resp_buffer: &[u8]) -> Result<(), StackError> {
-        
+    pub fn ssl_send_ecc_resp(
+        &mut self,
+        ecc_req: &EccReqInfo,
+        resp_buffer: &[u8],
+    ) -> Result<(), StackError> {
+        Ok()
     }
 }

--- a/winc-rs/src/client/ssl.rs
+++ b/winc-rs/src/client/ssl.rs
@@ -1,8 +1,73 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::StackError;
 use super::WincClient;
 use super::Xfer;
 
-use crate::manager::{EccReqInfo, SslCertExpiryOpt};
+use crate::manager::{EccPoint, EccRequest, SslCertExpiryOpt};
+
+// @note: The `m2m_ssl_retrieve_hash` API is not supported because
+// there is no way to validate that the SSL HIF register address
+// received from the ECC response callback points to the memory
+// region containing the certificate hash.
+
+/// SSL Cipher Suits
+/// By default, WINC1500 HW accelerator only supports AES-128.
+/// For using, AES-256 needs to be enabled.
+#[repr(u32)]
+pub enum SslCipherSuite {
+    // Individual Ciphers
+    RsaWithAes128CbcSha = 0x01,
+    RsaWithAes128CbcSha256 = 0x02,
+    DheRsaWithAes128CbcSha = 0x04,
+    DheRsaWithAes128CbcSha256 = 0x08,
+    RsaWithAes128GcmSha256 = 0x10,
+    DheRsaWithAes128GcmSha256 = 0x20,
+    RsaWithAes256CbcSha = 0x40,
+    RsaWithAes256CbcSha256 = 0x80,
+    DheRsaWithAes256CbcSha = 0x100,
+    DheRsaWithAes256CbcSha256 = 0x200,
+    EcdheRsaWithAes128CbcSha = 0x400,
+    EcdheRsaWithAes256CbcSha = 0x800,
+    EcdheRsaWithAes128CbcSha256 = 0x1000,
+    EcdheEcdsaWithAes128CbcSha256 = 0x2000,
+    EcdheRsaWithAes128GcmSha256 = 0x4000,
+    EcdheEcdsaWithAes128GcmSha256 = 0x8000,
+    // Grouped Ciphers
+    /// ECC ciphers using ECC authentication with AES 128 encryption only.
+    /// By default, this group is disabled on startup.
+    EccOnlyAes128 = 0xA000,
+    /// ECC ciphers using any authentication with AES-128 encryption.
+    /// By default, this group is disabled on startup.
+    EccAllAes128 = 0xF400,
+    /// All none ECC ciphers using AES-128 encryption.
+    /// By default, this group is active on startup.
+    NoEccAes128 = 0x3F,
+    /// All none ECC ciphers using AES-256 encryption.
+    NoEccAes256 = 0x3C0,
+    /// All supported ciphers.
+    /// By default, this group is disabled on startup.
+    AllCiphers = 0xFFFF,
+}
+
+/// Implementation to convert `SslCipherSuite` to `u32`.
+impl From<SslCipherSuite> for u32 {
+    fn from(val: SslCipherSuite) -> Self {
+        val as u32
+    }
+}
 
 impl<X: Xfer> WincClient<'_, X> {
     /// Configure the SSL certificate expiry option.
@@ -13,8 +78,8 @@ impl<X: Xfer> WincClient<'_, X> {
     ///
     /// # Returns
     ///
-    /// * `()` – If the request was successfully processed.
-    /// * `StackError` – If an error occurred while configuring the option.
+    /// * `Ok(())` – If the request was successfully processed.
+    /// * `Err(StackError)` – If an error occurred while configuring the option.
     pub fn ssl_check_cert_expiry(&mut self, opt: SslCertExpiryOpt) -> Result<(), StackError> {
         Ok(self.manager.send_ssl_cert_expiry(opt)?)
     }
@@ -27,17 +92,99 @@ impl<X: Xfer> WincClient<'_, X> {
     ///
     /// # Returns
     ///
-    /// * `()` – If the certificate was successfully sent.
-    /// * `StackError` – If an error occurred while sending the certificate.
+    /// * `Ok(())` – If the certificate was successfully sent.
+    /// * `Err(StackError)` – If an error occurred while sending the certificate.
     pub fn ssl_send_certificate(&mut self, cert: &[u8]) -> Result<(), StackError> {
         Ok(self.manager.send_ssl_cert(cert)?)
     }
 
+    /// Sends an ECC response to module.
+    ///
+    /// # Arguments
+    ///
+    /// * `ecc_req` – ECC request structure.
+    /// * `resp_buffer` - Buffer containing the ECC responses.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` – If the certificate was successfully sent.
+    /// * `Err(StackError)` – If an error occurred while sending the certificate.
     pub fn ssl_send_ecc_resp(
         &mut self,
-        ecc_req: &EccReqInfo,
+        ecc_req: &EccRequest,
         resp_buffer: &[u8],
     ) -> Result<(), StackError> {
-        Ok()
+        Ok(self.manager.send_ssl_ecc_resp(ecc_req, resp_buffer)?)
+    }
+
+    /// Reads the SSL response from the Module.
+    ///
+    /// # Arguments
+    ///
+    /// * `ecc_req` – ECC request structure.
+    /// * `resp_buffer` - Buffer containing the ECC responses.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` – If the certificate was successfully sent.
+    /// * `Err(StackError)` – If an error occurred while sending the certificate.
+    pub fn ssl_read_certificate(
+        &mut self,
+        curve_type: &mut u16,
+        hash: &mut [u8],
+        signature: &mut [u8],
+        ecc_point: &mut EccPoint,
+    ) -> Result<(), StackError> {
+        let mut hif_addr = self.callbacks.ssl_hif_reg.ok_or(StackError::InvalidState)?;
+        let mut opts = [0u8; 8]; // read the ssl options.
+
+        // Read the Curve Type, Key, Hash and Signature size.
+        self.manager.read_ssl_cert_feat(hif_addr, &mut opts)?;
+        hif_addr += 8;
+
+        // Parse the values from the buffer
+        *curve_type = u16::from_be_bytes([opts[0], opts[1]]);
+        ecc_point.point_size = u16::from_be_bytes([opts[2], opts[3]]);
+        let hash_size = u16::from_be_bytes([opts[4], opts[5]]);
+        let sig_size = u16::from_be_bytes([opts[6], opts[7]]);
+
+        // Read the ECC Point-X
+        let to_read_len = (ecc_point.point_size * 2) as usize;
+        if ecc_point.x_cord.len() < to_read_len {
+            return Err(StackError::InvalidParameters);
+        }
+
+        self.manager
+            .read_ssl_cert_feat(hif_addr, &mut ecc_point.x_cord[..to_read_len])?;
+        hif_addr += to_read_len as u32;
+
+        // Read the hash
+        self.manager
+            .read_ssl_cert_feat(hif_addr, &mut hash[..hash_size as usize])?;
+        hif_addr += hash_size as u32;
+
+        // Read the Signature
+        self.manager
+            .read_ssl_cert_feat(hif_addr, &mut signature[..sig_size as usize])?;
+
+        // clear the Hif register
+        self.callbacks.ssl_hif_reg = None;
+
+        // mark the Rx done
+        Ok(self.manager.send_ssl_cert_read_complete()?)
+    }
+
+    /// Sets the SSL/TLS cipher suite for the WINC module.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssl_cipher` -  Required cipher suit to set.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the cipher suite was successfully set.
+    /// * `Err(StackError)` - If an error occurred while applying the configuration.
+    pub fn ssl_set_cipher_suit(&mut self, ssl_cipher: SslCipherSuite) -> Result<(), StackError> {
+        Ok(self.manager.send_ssl_set_cipher_suit(ssl_cipher.into())?)
     }
 }

--- a/winc-rs/src/client/ssl.rs
+++ b/winc-rs/src/client/ssl.rs
@@ -1,0 +1,39 @@
+use super::StackError;
+use super::WincClient;
+use super::Xfer;
+
+use crate::manager::{SslCertExpiryOpt, EccReqInfo};
+
+impl<X: Xfer> WincClient<'_, X> {
+    /// Configure the SSL certificate expiry option.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` – The SSL certificate expiry option to apply.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the request was successfully processed.
+    /// * `StackError` – If an error occurred while configuring the option.
+    pub fn ssl_check_cert_expiry(&mut self, opt: SslCertExpiryOpt) -> Result<(), StackError> {
+        Ok(self.manager.send_ssl_cert_expiry(opt)?)
+    }
+
+    /// Sends an SSL certificate to the module.
+    ///
+    /// # Arguments
+    ///
+    /// * `cert` – A byte slice containing the SSL certificate data.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the certificate was successfully sent.
+    /// * `StackError` – If an error occurred while sending the certificate.
+    pub fn ssl_send_certificate(&mut self, cert: &[u8]) -> Result<(), StackError> {
+        Ok(self.manager.send_ssl_cert(cert)?)
+    }
+
+    pub fn ssl_handshake_resp(&mut self, ecc_req: &EccReqInfo, resp_buffer: &[u8]) -> Result<(), StackError> {
+        
+    }
+}

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -578,11 +578,11 @@ impl<X: Xfer> Manager<X> {
     /// * `gid` - HIF Group ID. (e.g., WiFi, IP, OTA, HIF).
     /// * `op` - Operation ID.
     /// * `len` - Length of data packet to send.
-    /// * `req_data` -  Request data from chip or not.
+    /// * `req_data` - Request data from chip or not.
     ///
     /// # Returns
     ///
-    /// * `()` - HIF header is successfully prepared and sent to chip.
+    /// * `()` - HIF header is successfully sent to chip.
     /// * `Error` - if any error occured while preparing or writing HIF header.
     fn prep_for_hif_send(
         &mut self,

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -44,8 +44,8 @@ pub(crate) use constants::{OtaRequest, OtaResponse, OtaUpdateStatus};
 pub(crate) use constants::{SslResponse, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
 
 pub use net_types::{
-    AccessPoint, Credentials, EccReqInfo, HostName, ProvisioningInfo, S8Password, S8Username,
-    SocketOptions, Ssid, SslSockConfig, SslSockOpts, TcpSockOpts, UdpSockOpts, WpaKey,
+    AccessPoint, Credentials, EccPoint, EccRequest, HostName, ProvisioningInfo, S8Password,
+    S8Username, SocketOptions, Ssid, SslSockConfig, SslSockOpts, TcpSockOpts, UdpSockOpts, WpaKey,
 };
 
 #[cfg(feature = "wep")]
@@ -78,6 +78,7 @@ macro_rules! get_ip_code {
 }
 
 /// HIF Response Group.
+#[allow(dead_code)] // todo! remove it once event listener is complete.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Default)]
 pub(crate) enum HifGroup {
@@ -674,9 +675,11 @@ impl<X: Xfer> Manager<X> {
         let len = match data_packet {
             Some((size, offset)) => HIF_HEADER_OFFSET + size + offset,
             None => payload.len() + HIF_HEADER_OFFSET,
-        };
+        } as u16;
+
         let pkglen = len.to_le_bytes();
         assert_eq!(pkglen[1], 0);
+
         // Operation ID.
         let opp: u8 = match req {
             HifRequest::Wifi(opcode) => opcode.into(),
@@ -687,7 +690,7 @@ impl<X: Xfer> Manager<X> {
         };
         // Group ID.
         let grpval = req.into();
-        self.prep_for_hif_send(grpval, opp, len as u16, req_data)?;
+        self.prep_for_hif_send(grpval, opp, len, req_data)?;
 
         self.chip.dma_block_write(
             self.not_a_reg_ctrl_4_dma,
@@ -1551,35 +1554,116 @@ impl<X: Xfer> Manager<X> {
 
         let reg: u32 = self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32 + cert.len() as u32;
 
-        self.chip.dma_block_write(reg, &cert)?;
+        self.chip.dma_block_write(reg, cert)?;
 
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
-    /// Sends a request to configure the provided SSL certificate.
+    /// Sends a ECC response to module.
     ///
     /// # Arguments
     ///
-    /// * `cert` - SSL certificate.
+    /// * `ecc_req` - ECC request
+    /// * `resp_buffer` - Response data to be sent.
     ///
     /// # Returns
     ///
     /// * `()` - If the request is successfully sent.
-    /// * `Error` - If an error occurs while preparing or sending the request
-    pub(crate) fn send_ssl_handshake_resp(
+    /// * `Error` - If an error occurs while preparing or sending the request.
+    pub(crate) fn send_ssl_ecc_resp(
         &mut self,
-        ecc_req: &EccReqInfo,
+        ecc_req: &EccRequest,
         resp_buffer: &[u8],
     ) -> Result<(), Error> {
+        let req = write_ssl_ecc_req(ecc_req)?;
+
         self.write_hif_header(
-            HifRequest::Ssl(SslRequest::SendCertificate),
-            &[0],
+            HifRequest::Ssl(SslRequest::SendEccResponse),
+            &req,
             true,
-            None,
+            Some((resp_buffer.len(), req.len())),
         )?;
 
+        // write the control packet
+        let mut reg = self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32;
+        self.chip.dma_block_write(reg, &req)?;
+
+        // write the data packet
+        reg += req.len() as u32;
+        self.chip.dma_block_write(reg, resp_buffer)?;
+
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
+    /// Reads SSL certificate features (curve type, hash algorithm,
+    /// and signature) from the WINC module.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The register address to start reading from.
+    /// * `resp_buff` - A mutable buffer to store the response data.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the data is successfully read.
+    /// * `Err(Error)` - If an error occurs while reading the data.
+    pub(crate) fn read_ssl_cert_feat(
+        &mut self,
+        address: u32,
+        resp_buff: &mut [u8],
+    ) -> Result<(), Error> {
+        let result = self
+            .chip
+            .dma_block_read(address + HIF_HEADER_OFFSET as u32, resp_buff);
+
+        // Set the RX done if error occurs
+        if result.is_err() {
+            error!(
+                "Failed to read SSL certificate feature at address {:x}",
+                address
+            );
+            error!("Sending request to stop reading from the module.");
+            let reg = self.chip.single_reg_read(Regs::WifiHostRcvCtrl0.into())?;
+            self.chip
+                .single_reg_write(Regs::WifiHostRcvCtrl0.into(), reg | 2)?;
+
+            return Err(Error::ReadError);
+        }
+
+        Ok(())
+    }
+
+    /// Sends a request to stop reading the certificate from the module.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the module successfully disables certificate reading.
+    /// * `Err(Error)` - If an error occurs while updating the module state.
+    pub(crate) fn send_ssl_cert_read_complete(&mut self) -> Result<(), Error> {
+        let reg = self.chip.single_reg_read(Regs::WifiHostRcvCtrl0.into())?;
         self.chip
-            .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &cert)?;
+            .single_reg_write(Regs::WifiHostRcvCtrl0.into(), reg | 2)
+    }
+
+    /// Sends a request to set the desired SSL cipher suite.
+    ///
+    /// # Arguments
+    ///
+    /// * `cipher_bitmap` - A `u32` bitmask representing the cipher suites to enable.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the request was successfully processed.
+    /// * `Err(Error)` - If an error occurs while updating the module state.
+    pub(crate) fn send_ssl_set_cipher_suit(&mut self, cipher_bitmap: u32) -> Result<(), Error> {
+        let req = cipher_bitmap.to_le_bytes();
+
+        self.write_hif_header(
+            HifRequest::Ssl(SslRequest::SetCipherSuits),
+            &req,
+            false,
+            None,
+        )?;
 
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -32,18 +32,20 @@ use chip_access::ChipAccess;
 pub use constants::OtaUpdateError;
 #[cfg(feature = "wep")]
 pub use constants::WepKeyIndex;
-pub use constants::{AuthType, PingError, SocketError, WifiChannel, WifiConnError, WifiConnState}; // todo response shouldn't be leaking
-use constants::{IpCode, Regs, WifiRequest, WifiResponse};
+pub use constants::{
+    AuthType, PingError, SocketError, SslCertExpiryOpt, WifiChannel, WifiConnError, WifiConnState,
+};
+use constants::{IpCode, Regs, SslRequest, WifiRequest, WifiResponse};
 
 #[cfg(feature = "flash-rw")]
 pub(crate) use constants::FLASH_PAGE_SIZE;
 #[cfg(feature = "experimental-ota")]
 pub(crate) use constants::{OtaRequest, OtaResponse, OtaUpdateStatus};
-pub(crate) use constants::{PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
+pub(crate) use constants::{SslResponse, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
 
 pub use net_types::{
-    AccessPoint, Credentials, HostName, ProvisioningInfo, S8Password, S8Username, SocketOptions,
-    Ssid, SslSockOpts, TcpSockOpts, UdpSockOpts, WpaKey,
+    AccessPoint, Credentials, EccReqInfo, HostName, ProvisioningInfo, S8Password, S8Username,
+    SocketOptions, Ssid, SslSockConfig, SslSockOpts, TcpSockOpts, UdpSockOpts, WpaKey,
 };
 
 #[cfg(feature = "wep")]
@@ -58,6 +60,23 @@ use core::net::{Ipv4Addr, SocketAddrV4};
 
 pub use responses::FirmwareInfo;
 
+/// Macro to select the appropriate `HifRequest::Ip` variant based on the socket's SSL config.
+///
+/// Usage: `get_ip_code!(socket, Recv, SslRecv)`
+///
+/// Expands to: `HifRequest::Ip(IpCode::SslRecv)` if SSL is enabled,
+///             `HifRequest::Ip(IpCode::Recv)` otherwise.
+#[macro_export]
+macro_rules! get_ip_code {
+    ($socket:expr, $normal:ident, $ssl:ident) => {
+        if ($socket.get_ssl_cfg() & u8::from(SslSockConfig::EnableSSL)) > 0 {
+            HifRequest::Ip(IpCode::$ssl)
+        } else {
+            HifRequest::Ip(IpCode::$normal)
+        }
+    };
+}
+
 /// HIF Response Group.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Default)]
@@ -68,6 +87,7 @@ pub(crate) enum HifGroup {
     Ip(IpCode),
     #[cfg(feature = "experimental-ota")]
     Ota(OtaResponse),
+    Ssl(SslResponse),
 }
 
 /// HIF Request Group.
@@ -77,6 +97,7 @@ enum HifRequest {
     Ip(IpCode),
     #[cfg(feature = "experimental-ota")]
     Ota(OtaRequest),
+    Ssl(SslRequest),
 }
 
 /// Implementation to convert `HifRequest` to `u8` value.
@@ -87,6 +108,7 @@ impl From<HifRequest> for u8 {
             HifRequest::Ip(_) => 2,
             #[cfg(feature = "experimental-ota")]
             HifRequest::Ota(_) => 4,
+            HifRequest::Ssl(_) => 5,
         }
     }
 }
@@ -179,6 +201,7 @@ pub trait EventListener {
     fn on_provisioning(&mut self, ssid: Ssid, key: WpaKey, security: AuthType, status: bool);
     #[cfg(feature = "experimental-ota")]
     fn on_ota(&mut self, status: OtaUpdateStatus, error: OtaUpdateError);
+    fn on_ssl(&mut self, ssl_res: SslResponse, response: &[u8]);
 }
 
 pub struct Manager<X: Xfer> {
@@ -660,6 +683,7 @@ impl<X: Xfer> Manager<X> {
             HifRequest::Ip(opcode) => opcode.into(),
             #[cfg(feature = "experimental-ota")]
             HifRequest::Ota(opcode) => opcode.into(),
+            HifRequest::Ssl(opcode) => opcode.into(),
         };
         // Group ID.
         let grpval = req.into();
@@ -769,10 +793,23 @@ impl<X: Xfer> Manager<X> {
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, req)?;
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
+
+    /// Sends a request to bind the socket to the specified IPv4 address.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` – The socket to bind.
+    /// * `address` – The local IPv4 address and port to bind the socket to.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the bind request was successfully sent.
+    /// * `Error` – If an error occurred while sending the bind request.
     pub fn send_bind(&mut self, socket: Socket, address: SocketAddrV4) -> Result<(), Error> {
-        // todo: address family is useless here
-        let req = write_bind_req(socket, 2, address)?;
-        self.write_hif_header(HifRequest::Ip(IpCode::Bind), &req, false, None)?;
+        let req = write_bind_req(socket, address)?;
+        let cmd = get_ip_code!(socket, Bind, SslBind);
+
+        self.write_hif_header(cmd, &req, false, None)?;
         self.chip
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
@@ -785,13 +822,26 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a request to initiate a socket connection to the specified IPv4 address.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` – The socket identifier to use for the connection.
+    /// * `address` – The IPv4 address and port to connect to.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the connection request was successfully sent.
+    /// * `Error` – If an error occurred while sending the connection request.
     pub fn send_socket_connect(
         &mut self,
         socket: Socket,
         address: SocketAddrV4,
     ) -> Result<(), Error> {
-        let req = write_connect_req(socket, 2, address, 0)?;
-        self.write_hif_header(HifRequest::Ip(IpCode::Connect), &req, false, None)?;
+        let req = write_connect_req(socket, 2, address, socket.get_ssl_cfg())?;
+        let cmd = get_ip_code!(socket, Connect, SslConnect);
+
+        self.write_hif_header(cmd, &req, false, None)?;
         self.chip
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
@@ -816,6 +866,17 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a TCP send request.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` – The socket through which to send the data.
+    /// * `data` – A byte slice containing the data to be sent.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the data was successfully queued or sent.
+    /// * `Error` – If an error occurred during the send operation.
     pub fn send_send(&mut self, socket: Socket, data: &[u8]) -> Result<(), Error> {
         const TCP_IP_HEADER_LENGTH: usize = 40;
         const TCP_TX_PACKET_OFFSET: usize = IP_PACKET_OFFSET + TCP_IP_HEADER_LENGTH;
@@ -827,7 +888,10 @@ impl<X: Xfer> Manager<X> {
             SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0),
             data.len(),
         )?;
-        self.write_hif_header(HifRequest::Ip(IpCode::Send), &req, true, None)?;
+
+        let cmd = get_ip_code!(socket, Send, SslSend);
+
+        self.write_hif_header(cmd, &req, true, None)?;
         self.chip
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
         self.chip.dma_block_write(
@@ -837,9 +901,22 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a request to receive data from the specified socket with a timeout.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` – The socket from which to receive data.
+    /// * `timeout` – The receive timeout in milliseconds.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the receive request was successfully sent.
+    /// * `Error` – If an error occurred while sending the receive request.
     pub fn send_recv(&mut self, socket: Socket, timeout: u32) -> Result<(), Error> {
         let req = write_recv_req(socket, timeout)?;
-        self.write_hif_header(HifRequest::Ip(IpCode::Recv), &req, false, None)?;
+        let cmd = get_ip_code!(socket, Recv, SslRecv);
+
+        self.write_hif_header(cmd, &req, false, None)?;
         self.chip
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
@@ -853,9 +930,21 @@ impl<X: Xfer> Manager<X> {
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a request to close the specified socket.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` – The socket to be closed.
+    ///
+    /// # Returns
+    ///
+    /// * `()` – If the close request was successfully sent.
+    /// * `Error` – If an error occurred while sending the request.
     pub fn send_close(&mut self, socket: Socket) -> Result<(), Error> {
         let req = write_close_req(socket)?;
-        self.write_hif_header(HifRequest::Ip(IpCode::Close), &req, false, None)?;
+        let cmd = get_ip_code!(socket, Close, SslClose);
+
+        self.write_hif_header(cmd, &req, false, None)?;
         self.chip
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &req)?;
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
@@ -1405,6 +1494,75 @@ impl<X: Xfer> Manager<X> {
         self.chip
             .dma_block_read(Regs::FlashSharedMemory.into(), buffer)
     }
+
+    /// Send a request to create a SSL socket.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` - The socket to which the SSL will be enabled.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs while preparing or sending the request.
+    pub(crate) fn send_ssl_sock_create(&mut self, socket: Socket) -> Result<(), Error> {
+        let req: [u8; 4] = [socket.v, 0, 0, 0];
+
+        self.write_hif_header(HifRequest::Ip(IpCode::SslCreate), &req, false)?;
+
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
+    /// Sends a request to configure the SSL certificate expiry option.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - The SSL certificate expiry option to configure.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs while preparing or sending the request.
+    pub(crate) fn send_ssl_cert_expiry(&mut self, opt: SslCertExpiryOpt) -> Result<(), Error> {
+        let req = u32::to_be_bytes(opt.into());
+
+        self.write_hif_header(HifRequest::Ip(IpCode::SslExpCheck), &req, false)?;
+
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
+    /// Sends a request to configure the provided SSL certificate.
+    ///
+    /// # Arguments
+    ///
+    /// * `cert` - SSL certificate.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs while preparing or sending the request.
+    pub(crate) fn send_ssl_cert(&mut self, cert: &[u8]) -> Result<(), Error> {
+        self.write_hif_header(HifRequest::Ssl(SslRequest::SendCertificate), &[0], true)?;
+
+        self.chip
+            .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &cert)?;
+
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
+    pub(crate) fn send_ssl_handshake_resp(
+        &mut self,
+        ecc_req: &EccReqInfo,
+        resp_buffer: &[u8],
+    ) -> Result<(), Error> {
+        self.write_hif_header(HifRequest::Ssl(SslRequest::SendCertificate), &[0], true)?;
+
+        self.chip
+            .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &cert)?;
+
+        self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
+    }
+
     // #endregion write
 }
 

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -1508,7 +1508,7 @@ impl<X: Xfer> Manager<X> {
     pub(crate) fn send_ssl_sock_create(&mut self, socket: Socket) -> Result<(), Error> {
         let req: [u8; 4] = [socket.v, 0, 0, 0];
 
-        self.write_hif_header(HifRequest::Ip(IpCode::SslCreate), &req, false)?;
+        self.write_hif_header(HifRequest::Ip(IpCode::SslCreate), &req, false, None)?;
 
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
@@ -1526,7 +1526,7 @@ impl<X: Xfer> Manager<X> {
     pub(crate) fn send_ssl_cert_expiry(&mut self, opt: SslCertExpiryOpt) -> Result<(), Error> {
         let req = u32::to_be_bytes(opt.into());
 
-        self.write_hif_header(HifRequest::Ip(IpCode::SslExpCheck), &req, false)?;
+        self.write_hif_header(HifRequest::Ip(IpCode::SslExpCheck), &req, false, None)?;
 
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
@@ -1542,20 +1542,41 @@ impl<X: Xfer> Manager<X> {
     /// * `()` - If the request is successfully sent.
     /// * `Error` - If an error occurs while preparing or sending the request.
     pub(crate) fn send_ssl_cert(&mut self, cert: &[u8]) -> Result<(), Error> {
-        self.write_hif_header(HifRequest::Ssl(SslRequest::SendCertificate), &[0], true)?;
+        self.write_hif_header(
+            HifRequest::Ssl(SslRequest::SendCertificate),
+            &[0],
+            true,
+            Some((cert.len(), 0)),
+        )?;
 
-        self.chip
-            .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &cert)?;
+        let reg: u32 = self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32 + cert.len() as u32;
+
+        self.chip.dma_block_write(reg, &cert)?;
 
         self.write_ctrl3(self.not_a_reg_ctrl_4_dma)
     }
 
+    /// Sends a request to configure the provided SSL certificate.
+    ///
+    /// # Arguments
+    ///
+    /// * `cert` - SSL certificate.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the request is successfully sent.
+    /// * `Error` - If an error occurs while preparing or sending the request
     pub(crate) fn send_ssl_handshake_resp(
         &mut self,
         ecc_req: &EccReqInfo,
         resp_buffer: &[u8],
     ) -> Result<(), Error> {
-        self.write_hif_header(HifRequest::Ssl(SslRequest::SendCertificate), &[0], true)?;
+        self.write_hif_header(
+            HifRequest::Ssl(SslRequest::SendCertificate),
+            &[0],
+            true,
+            None,
+        )?;
 
         self.chip
             .dma_block_write(self.not_a_reg_ctrl_4_dma + HIF_HEADER_OFFSET as u32, &cert)?;

--- a/winc-rs/src/manager/constants.rs
+++ b/winc-rs/src/manager/constants.rs
@@ -514,11 +514,11 @@ impl From<u8> for OtaUpdateStatus {
 #[repr(u8)]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum SslRequest {
-    Unhandled = 0xff, // Invalid Request
+    Unhandled = 0xff,       // Invalid Request
     SendEccResponse = 0x02, // Send ECC Response
-    NotifyCrl = 0x03, // Update Certificate Revocation List
+    NotifyCrl = 0x03,       // Update Certificate Revocation List
     SendCertificate = 0x04, // Send ECC Certificates
-    SetCipherSuits = 0x05, // Set the custom ciphers suits list
+    SetCipherSuits = 0x05,  // Set the custom ciphers suits list
 }
 
 /// SSL responses
@@ -526,9 +526,9 @@ pub(crate) enum SslRequest {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum SslResponse {
-    EccUpdate = 0x01, // Response of ECC command.
+    EccUpdate = 0x01,        // Response of ECC command.
     CipherSuitUpdate = 0x06, // Response of requested changes in Cipher Suits.
-    Unhandled = 0xff, // Invalid response recevied.
+    Unhandled = 0xff,        // Invalid response recevied.
 }
 
 /// Convert `SslRequest` to `u8` value.
@@ -546,7 +546,7 @@ impl From<SslResponse> for u8 {
 }
 
 /// Convert `SslResponse` to `u8` value.
-impl From<u8> for SslResponse{
+impl From<u8> for SslResponse {
     fn from(val: u8) -> Self {
         match val {
             0x01 => SslResponse::EccUpdate,
@@ -557,7 +557,7 @@ impl From<u8> for SslResponse{
 }
 
 /// Convert `SslRequest` to `u8` value.
-impl From<u8> for SslRequest{
+impl From<u8> for SslRequest {
     fn from(val: u8) -> Self {
         match val {
             0x02 => SslRequest::SendEccResponse,

--- a/winc-rs/src/manager/event_listener.rs
+++ b/winc-rs/src/manager/event_listener.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use super::{EventListener, Manager};
-use super::{HifGroup, IpCode, WifiResponse, SslResponse};
+use super::{HifGroup, IpCode, SslResponse, WifiResponse};
 use crate::errors::CommError as Error;
 use crate::manager::constants::{
     PRNG_DATA_LENGTH, PRNG_PACKET_SIZE, PROVISIONING_INFO_PACKET_SIZE, SOCKET_BUFFER_MAX_LENGTH,
 };
 use crate::manager::responses::*;
-use crate::{transfer::Xfer, error};
+use crate::{error, transfer::Xfer};
 
 #[cfg(feature = "experimental-ota")]
 use crate::manager::constants::OtaResponse;

--- a/winc-rs/src/manager/net_types.rs
+++ b/winc-rs/src/manager/net_types.rs
@@ -145,34 +145,50 @@ pub struct AccessPoint<'a> {
     pub ip: Ipv4Addr,
 }
 
-pub struct EcdhRequest {
+/// Elliptic Curve Point
+pub struct EccPoint {
     /// The X-coordinate of the ec point.
-    x_cord: [u8; EC_POINT_MAX_SIZE],
+    pub x_cord: [u8; EC_POINT_MAX_SIZE],
     /// The Y-coordinate of the ec point.
-    y_cord: [u8; EC_POINT_MAX_SIZE],
+    pub y_cord: [u8; EC_POINT_MAX_SIZE],
     // Point size in bytes (for each of the coordinates).
-    point_size: u16,
+    pub point_size: u16,
     /// ID for the corresponding private key.
-    private_key_id: u16,
+    pub private_key_id: u16,
+}
+
+/// Elliptic Curve Diffie-Hellman (ECDH) request.
+pub struct EcdhRequest {
+    /// ECC points or EC public key.
+    pub ecc_point: EccPoint,
     /// Private Key
-    private_key: [u8; EC_POINT_MAX_SIZE]
+    pub private_key: [u8; EC_POINT_MAX_SIZE],
 }
 
+/// Elliptic Curve Digital Signature Algorithm (ECDSA) signing request.
 pub struct EcdsaSignRequest {
-    /// Key Curve Type
-    curve_type: u16,
-    /// Hash Size
-    hash_size: u16,
+    /// Key Curve Type (NIST P-256, P-384)
+    pub curve_type: u16,
+    /// Hash Size (32 bytes for SHA-256 or 48 bytes for SHA-384)
+    pub hash_size: u16,
 }
 
-pub struct EccReqInfo {
-    req: u16,
-    status: u16,
-    user_data: u32,
-    seq_num: u32,
-    ecdh_req: Option<EcdhRequest>,
-    ecdsa_sign_req: Option<EcdsaSignRequest>,
-    ecdsa_verify_req: Option<u32>,
+/// ECC Request
+pub struct EccRequest {
+    /// ECC Request type (ECDH, ECDSA Sign or ECDSA Verify)
+    pub req: u16,
+    /// Status of ECC operation.
+    pub status: u16,
+    /// User data
+    pub user_data: u32,
+    /// Sequence number
+    pub seq_num: u32,
+    /// Optional ECDH request
+    pub ecdh_req: Option<EcdhRequest>,
+    /// Optional ECDSA signing request
+    pub ecdsa_sign_req: Option<EcdsaSignRequest>,
+    /// Optional ECDSA signature verification request.
+    pub ecdsa_verify_req: Option<u32>,
 }
 
 /// Implementation to convert the Credentials to Authentication Type

--- a/winc-rs/src/manager/requests.rs
+++ b/winc-rs/src/manager/requests.rs
@@ -24,8 +24,11 @@ use super::constants::{
     SET_SOCK_OPTS_PACKET_SIZE, SET_SSL_SOCK_OPTS_PACKET_SIZE, START_PROVISION_PACKET_SIZE,
 };
 
-use super::net_types::{Ssid, SslSockOpts, WepKey};
+use super::net_types::{EccRequest, Ssid, SslSockOpts, WepKey};
 use super::{AccessPoint, Credentials, HostName};
+
+/// Packet Size of SSL ECC request.
+const SSL_ECC_REQ_PACKET_SIZE: usize = 44;
 
 /// Prepares the packet to connect to access point.
 ///
@@ -493,6 +496,57 @@ pub fn write_en_ap_req(ap: &AccessPoint) -> Result<[u8; ENABLE_AP_PACKET_SIZE], 
     slice.write(&dhcp.to_be_bytes())?;
     // WPA key (65 byte)
     slice.write(wpa_key.as_bytes())?;
+
+    Ok(req)
+}
+
+/// Prepares the packet for writing an SSL ECC request.
+///
+/// # Arguments
+///
+/// * `EccReqInfo` - ECC Request Info.
+///
+/// # Returns
+///
+/// * `[u8; SSL_ECC_REQ_PACKET_SIZE])` - The ECC request packet as a fixed-size byte array.
+/// * `BufferOverflow` - If the input data exceeds the allowed size or buffer limit.
+pub(crate) fn write_ssl_ecc_req(
+    ecc_req: &EccRequest,
+) -> Result<[u8; SSL_ECC_REQ_PACKET_SIZE], BufferOverflow> {
+    let mut req = [0u8; SSL_ECC_REQ_PACKET_SIZE];
+    let mut slice = req.as_mut_slice();
+
+    // Request (2 bytes)
+    slice.write(&ecc_req.req.to_le_bytes())?;
+    // Status (2 bytes)
+    slice.write(&ecc_req.status.to_be_bytes())?;
+    // User data (4 bytes)
+    slice.write(&ecc_req.user_data.to_be_bytes())?;
+    // Sequence Number (4 bytes)
+    slice.write(&ecc_req.seq_num.to_be_bytes())?;
+
+    if let Some(ecdh_req) = ecc_req.ecdh_req.as_ref() {
+        // X-cordinates of EC points (32 bytes)
+        slice.write(&ecdh_req.ecc_point.x_cord)?;
+        // Y-cordinates of EC points (32 bytes)
+        slice.write(&ecdh_req.ecc_point.y_cord)?;
+        // Point Size (2 bytes)
+        slice.write(&ecdh_req.ecc_point.point_size.to_le_bytes())?;
+        // Private Key ID (2 bytes)
+        slice.write(&ecdh_req.ecc_point.private_key_id.to_le_bytes())?;
+        // Private Key (32 bytes)
+        slice.write(&ecdh_req.private_key)?;
+    } else if let Some(ecdsa_sign_req) = ecc_req.ecdsa_sign_req.as_ref() {
+        // Curve Type (2 bytes)
+        slice.write(&ecdsa_sign_req.curve_type.to_le_bytes())?;
+        // Hash Size (2 bytes)
+        slice.write(&ecdsa_sign_req.hash_size.to_le_bytes())?;
+    } else if let Some(ecdsa_ver_req) = ecc_req.ecdsa_verify_req.as_ref() {
+        // ECDSA Sign
+        slice.write(&ecdsa_ver_req.to_le_bytes())?;
+    } else {
+        // do nothing
+    }
 
     Ok(req)
 }

--- a/winc-rs/src/socket.rs
+++ b/winc-rs/src/socket.rs
@@ -25,6 +25,8 @@ pub struct Socket {
     pub s: u16,
     /// Receive Timeout.
     receive_timeout: u32,
+    /// SSL Configuration
+    ssl_cfg: u8,
 }
 
 /// Implementation of `Socket` to create new instance and managing the receive timeout.
@@ -44,6 +46,7 @@ impl Socket {
             v,
             s,
             receive_timeout: DEFAULT_SOCKET_RECEIVE_TIMEOUT,
+            ssl_cfg: 0,
         }
     }
 
@@ -52,13 +55,31 @@ impl Socket {
     /// # Arguments
     ///
     /// * `timeout` - Timeout duration in milliseconds.
-    pub fn set_recv_timeout(&mut self, timeout: u32) {
+    pub(crate) fn set_recv_timeout(&mut self, timeout: u32) {
         self.receive_timeout = timeout;
     }
 
     /// Returns the receive timeout of the socket, in milliseconds.
-    pub fn get_recv_timeout(&self) -> u32 {
+    pub(crate) fn get_recv_timeout(&self) -> u32 {
         self.receive_timeout
+    }
+
+    /// Set the SSL Options
+    ///
+    /// # Arguments
+    ///
+    /// * `ssl_opt` - SSL socket options.
+    pub(crate) fn set_ssl_cfg(&mut self, ssl_opt: u8, enable: bool) {
+        if enable {
+            self.ssl_cfg |= ssl_opt;
+        } else {
+            self.ssl_cfg &= !ssl_opt;
+        }
+    }
+
+    /// Returns the SSL options value set on a socket.
+    pub fn get_ssl_cfg(&self) -> u8 {
+        self.ssl_cfg
     }
 }
 
@@ -69,6 +90,7 @@ impl From<(u8, u16)> for Socket {
             v: val.0,
             s: val.1,
             receive_timeout: DEFAULT_SOCKET_RECEIVE_TIMEOUT,
+            ssl_cfg: 0,
         }
     }
 }

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -18,7 +18,7 @@ use crate::socket::Socket;
 use crate::Ipv4AddrFormatWrapper;
 
 use super::SockHolder;
-use crate::manager::{PingError, ScanResult, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
+use crate::manager::{PingError, ScanResult, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH, SslResponse};
 
 use crate::stack::sock_holder::SocketStore;
 
@@ -777,5 +777,15 @@ impl EventListener for SocketCallbacks {
                 self.ota_state // retain the value if conditions dosen't match
             }
         };
+    }
+
+    /// Callback function for SSL events.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssl_res` - SSL response type.
+    /// * `response` - Response read from module.
+    fn on_ssl(&mut self, ssl_res: SslResponse, response: &[u8]) {
+        todo!("SSL Todo");
     }
 }

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -18,7 +18,9 @@ use crate::socket::Socket;
 use crate::Ipv4AddrFormatWrapper;
 
 use super::SockHolder;
-use crate::manager::{PingError, ScanResult, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH, SslResponse};
+use crate::manager::{
+    PingError, ScanResult, SslResponse, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH,
+};
 
 use crate::stack::sock_holder::SocketStore;
 
@@ -148,6 +150,7 @@ pub(crate) struct SocketCallbacks {
     pub provisioning_info: Option<Option<ProvisioningInfo>>,
     #[cfg(feature = "experimental-ota")]
     pub ota_state: OtaUpdateState,
+    pub ssl_hif_reg: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -262,6 +265,7 @@ impl SocketCallbacks {
             provisioning_info: None,
             #[cfg(feature = "experimental-ota")]
             ota_state: OtaUpdateState::NotStarted,
+            ssl_hif_reg: None,
         }
     }
     pub fn resolve(&mut self, socket: Socket) -> Option<&mut (Socket, ClientSocketOp)> {
@@ -785,7 +789,7 @@ impl EventListener for SocketCallbacks {
     ///
     /// * `ssl_res` - SSL response type.
     /// * `response` - Response read from module.
-    fn on_ssl(&mut self, ssl_res: SslResponse, response: &[u8]) {
+    fn on_ssl(&mut self, _ssl_res: SslResponse, _response: &[u8]) {
         todo!("SSL Todo");
     }
 }


### PR DESCRIPTION
This PR adds the following support for SSL APIs:
1. Support for SSL sockets.
2. Support for reading and writing SSL certificates, and checking their expiry.
3. Support for setting SSL cipher suites.

This PR also includes the changeset from PR #113.

**Pending:**
1. Unit test cases.
2. Testing on hardware.
3. Making SSL as optional feature.