### PR TITLE
Added support to connect with AP in Async

### DIFF
--- a/feather_async/examples/connect_network.rs
+++ b/feather_async/examples/connect_network.rs
@@ -1,0 +1,57 @@
+#![no_std]
+#![no_main]
+
+use embassy_time::Timer;
+use feather_async::hal::ehal::digital::OutputPin;
+use feather_async::init::init;
+use feather_async::shared::SpiStream;
+use wincwifi::{AsyncClient, Credentials, Ssid, StackError, WifiChannel};
+
+const DEFAULT_TEST_SSID: &str = "network";
+const DEFAULT_TEST_PASSWORD: &str = "password";
+
+async fn program() -> Result<(), StackError> {
+    if let Ok(ini) = init().await {
+        defmt::info!("Hello, Winc Connect to Access Point Async Module");
+
+        let mut red_led = ini.red_led;
+        let ssid = Ssid::from(option_env!("TEST_SSID").unwrap_or(DEFAULT_TEST_SSID)).unwrap();
+        let password = option_env!("TEST_PASSWORD").unwrap_or(DEFAULT_TEST_PASSWORD);
+        let credentials = Credentials::from_wpa(password)?;
+
+        defmt::info!(
+            "Connecting to network: {} with password: {}",
+            ssid.as_str(),
+            password
+        );
+
+        let mut module = AsyncClient::new(SpiStream::new(ini.cs, ini.spi));
+        defmt::info!("Initializing module");
+        module.start_wifi_module().await?;
+
+        defmt::info!("Connecting to Access point...");
+        module
+            .connect_to_ap(&ssid, &credentials, WifiChannel::ChannelAll, false)
+            .await?;
+        defmt::info!("Connected to Access point...");
+
+        loop {
+            Timer::after_millis(200).await;
+            red_led.set_high().unwrap();
+            Timer::after_millis(200).await;
+            red_led.set_low().unwrap();
+        }
+    }
+    Ok(())
+}
+
+#[embassy_executor::main]
+async fn main(_s: embassy_executor::Spawner) -> ! {
+    if let Err(err) = program().await {
+        defmt::error!("Error: {}", err);
+        panic!("Error in main program");
+    } else {
+        defmt::info!("Good exit")
+    };
+    loop {}
+}

--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -1,6 +1,6 @@
 use super::AsyncClient;
 use super::StackError;
-use crate::manager::{BootMode, BootState};
+use crate::manager::{BootMode, BootState, Credentials, Ssid, WifiChannel};
 use crate::stack::socket_callbacks::WifiModuleState;
 use crate::transfer::Xfer;
 
@@ -9,6 +9,13 @@ use crate::transfer::Xfer;
 const AP_CONNECT_TIMEOUT_MILLISECONDS: u32 = 60_000;
 
 impl<X: Xfer> AsyncClient<'_, X> {
+    /// Initializes the Wifi module in normal mode - boots the firmware and
+    /// completes the remaining initialization.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - The Wifi module has started successfully.
+    /// * `StackError` - Starting the Wifi module failed.
     pub async fn start_wifi_module(&mut self) -> Result<(), StackError> {
         if self.callbacks.borrow().state != WifiModuleState::Reset {
             return Err(StackError::InvalidState);
@@ -27,23 +34,31 @@ impl<X: Xfer> AsyncClient<'_, X> {
             self.yield_once().await; // todo: busy loop, maybe should delay here
         }
     }
-    pub async fn connect_to_saved_ap(&mut self) -> Result<(), StackError> {
-        if matches!(
-            self.callbacks.borrow().state,
-            WifiModuleState::Reset | WifiModuleState::Starting
-        ) {
-            return Err(StackError::InvalidState);
-        }
+
+    /// Connects with the access point by calling the provided connection function.
+    ///
+    /// # Arguments
+    ///
+    /// * `connect_fn` - A closure taking `&mut self` that performs the low-level
+    ///   connection operation and returns a `CommError` on failure.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Successfully connected to the access point.
+    /// * `StackError` - If an error occurs while connecting.
+    async fn connect_to_ap_impl(
+        &mut self,
+        connect_fn: impl Fn(&mut Self) -> Result<(), crate::errors::CommError>,
+    ) -> Result<(), StackError> {
         let mut countdown = AP_CONNECT_TIMEOUT_MILLISECONDS;
-        self.callbacks.borrow_mut().state = WifiModuleState::ConnectingToAp;
-        self.manager.borrow_mut().send_default_connect()?;
+
         loop {
-            countdown -= 1;
-            if countdown == 0 {
-                return Err(StackError::GeneralTimeout);
-            }
             let read_state = self.callbacks.borrow().state.clone();
             match read_state {
+                WifiModuleState::Unconnected => {
+                    self.callbacks.borrow_mut().state = WifiModuleState::ConnectingToAp;
+                    connect_fn(self)?;
+                }
                 WifiModuleState::ConnectionFailed => {
                     let mut callbacks = self.callbacks.borrow_mut();
                     // conn_error should always be Some in ConnectionFailed state,
@@ -55,13 +70,60 @@ impl<X: Xfer> AsyncClient<'_, X> {
                         .unwrap_or(crate::manager::WifiConnError::Unhandled);
                     return Err(StackError::ApJoinFailed(res));
                 }
+                WifiModuleState::ConnectingToAp => {
+                    countdown -= 1;
+                    if countdown == 0 {
+                        return Err(StackError::GeneralTimeout);
+                    }
+                }
                 WifiModuleState::ConnectedToAp => {
                     return Ok(());
                 }
-                _ => {}
+                _ => {
+                    return Err(StackError::InvalidState);
+                }
             }
             self.dispatch_events()?;
             self.yield_once().await;
         }
+    }
+
+    /// Connect to access point with previously saved credentials.
+    pub async fn connect_to_saved_ap(&mut self) -> Result<(), StackError> {
+        self.connect_to_ap_impl(|inner_self: &mut Self| {
+            inner_self.manager.borrow_mut().send_default_connect()
+        })
+        .await
+    }
+
+    /// Connects to the access point with the given SSID and credentials.
+    ///
+    /// # Arguments
+    ///
+    /// * `ssid` - The SSID of the access point to connect to.
+    /// * `credentials` - Security credentials (e.g., passphrase or authentication data).
+    /// * `channel` - Wi-Fi RF channel (e.g., 1-14 or 255 to select all channels).
+    /// * `save_credentials` - Whether to store the credentials persistently on the module.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - Successfully connected to the access point.
+    /// * `StackError` - If the connection to the access point fails.
+    pub async fn connect_to_ap(
+        &mut self,
+        ssid: &Ssid,
+        credentials: &Credentials,
+        channel: WifiChannel,
+        save_credentials: bool,
+    ) -> Result<(), StackError> {
+        self.connect_to_ap_impl(|inner_self: &mut Self| {
+            inner_self.manager.borrow_mut().send_connect(
+                ssid,
+                credentials,
+                channel,
+                !save_credentials,
+            )
+        })
+        .await
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add async access point connection capabilities and example usage for the WiFi module.

New Features:
- Introduce a generic async access point connection routine that supports both saved and explicit credentials.
- Expose a new async API to connect to an access point using a provided SSID, credentials, and channel settings.
- Provide an async example program demonstrating WiFi module initialization and connection to a network on Feather hardware.

Enhancements:
- Refine async WiFi connection state handling to validate states, handle timeouts explicitly while connecting, and surface connection failures consistently.
- Document the async WiFi module startup and access point connection APIs with Rustdoc comments for clearer usage.