### PR TITLE
BUG: Fix HIF header offset and TCP/UDP multi-iteration send issue

### DIFF
--- a/winc-rs/src/client/tcp_stack.rs
+++ b/winc-rs/src/client/tcp_stack.rs
@@ -268,6 +268,33 @@ mod test {
     }
 
     #[test]
+    fn test_tcp_send_chunked_callback() {
+        let mut client = make_test_client();
+        let mut tcp_socket = client.socket().unwrap();
+        let packet = "Hello, World";
+
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_send(Socket::new(0, 0), 9 as i16);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+
+        let result = {
+            // send request + poll for callback (9 bytes polled)
+            let _ = client.send(&mut tcp_socket, packet.as_bytes());
+            // update the chunk
+            let mut debug = |callbacks: &mut SocketCallbacks| {
+                callbacks.on_send(Socket::new(0, 0), 3 as i16);
+            };
+            client.debug_callback = Some(&mut debug);
+            // poll second callback (3 bytes polled) and get result
+            client.send(&mut tcp_socket, packet.as_bytes())
+        };
+
+        assert_eq!(result.ok(), Some(packet.len()));
+    }
+
+    #[test]
     fn test_tcp_receive() {
         let mut client = make_test_client();
         let mut tcp_socket = client.socket().unwrap();

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -354,6 +354,34 @@ mod test {
     }
 
     #[test]
+    fn test_udp_send_chunked_callback() {
+        let mut client = make_test_client();
+        let mut udp_socket = client.socket().unwrap();
+        let packet = "Hello, World"; // 12 bytes
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80);
+
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_send_to(Socket::new(7, 0), 9 as i16);
+        };
+
+        client.debug_callback = Some(&mut my_debug);
+
+        let result = {
+            // send request + poll for callback (9 bytes polled)
+            let _ = client.send_to(&mut udp_socket, socket_addr, packet.as_bytes());
+            // update the chunk
+            let mut debug = |callbacks: &mut SocketCallbacks| {
+                callbacks.on_send_to(Socket::new(7, 0), 3 as i16);
+            };
+            client.debug_callback = Some(&mut debug);
+            // poll second callback (3 bytes polled) and get result
+            client.send_to(&mut udp_socket, socket_addr, packet.as_bytes())
+        };
+
+        assert_eq!(result.ok(), Some(()));
+    }
+
+    #[test]
     fn test_udp_check_max_send_buffer() {
         let mut client = make_test_client();
         let mut udp_socket = client.socket().unwrap();

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -576,11 +576,14 @@ impl<X: Xfer> Manager<X> {
         req: HifRequest,
         payload: &[u8],
         req_data: bool,
-        data_packet: Option<(usize /* Data Size */, usize /* Offset */)>,
+        data_packet: Option<(
+            usize, /* Data Size */
+            usize, /* Offset (Add `HIF_HEADER_OFFSET` if required.) */
+        )>,
     ) -> Result<u32, Error> {
         // Length of packet to send.
         let len = match data_packet {
-            Some((size, offset)) => HIF_HEADER_OFFSET + size + offset,
+            Some((size, offset)) => size + offset,
             None => payload.len() + HIF_HEADER_OFFSET,
         };
 
@@ -1488,7 +1491,12 @@ impl<X: Xfer> Manager<X> {
         const UDP_IP_HEADER_LENGTH: usize = 28;
         const UDP_TX_PACKET_OFFSET: usize = IP_PACKET_OFFSET + UDP_IP_HEADER_LENGTH;
         let req = write_sendto_req(socket, AF_INET, address, data.len())?;
-        let addr = self.write_hif_header(HifRequest::Ip(IpCode::SendTo), &req, true)?;
+        let addr = self.write_hif_header_impl(
+            HifRequest::Ip(IpCode::SendTo),
+            &req,
+            true,
+            Some((data.len(), UDP_TX_PACKET_OFFSET)),
+        )?;
         self.chip
             .dma_block_write(addr + HIF_HEADER_OFFSET as u32, &req)?;
         self.chip
@@ -2164,7 +2172,7 @@ impl<X: Xfer> Manager<X> {
             HifRequest::Ssl(SslRequest::SendEccResponse),
             &req,
             true,
-            Some((resp_buffer.len(), req.len())),
+            Some((resp_buffer.len(), req.len() + HIF_HEADER_OFFSET)),
         )?;
 
         // write the control packet
@@ -2312,7 +2320,7 @@ impl<X: Xfer> Manager<X> {
             HifRequest::Wifi(WifiRequest::SendEthernetPacket),
             &req,
             true,
-            Some((net_pkt.len(), ETHERNET_HEADER_OFFSET - HIF_HEADER_OFFSET)),
+            Some((net_pkt.len(), ETHERNET_HEADER_OFFSET)),
         )?;
 
         self.chip

--- a/winc-rs/src/net_ops/tcp_send.rs
+++ b/winc-rs/src/net_ops/tcp_send.rs
@@ -37,7 +37,7 @@ impl<X: Xfer> OpImpl<X> for TcpSendOp<'_> {
 
         match op {
             ClientSocketOp::AsyncOp(AsyncOp::Send(req, Some(len)), AsyncState::Done) => {
-                // Validate callback length parameter
+                // Validate callback length parameter for error.
                 let callback_len = *len;
                 if callback_len < 0 {
                     // Negative length is invalid - treat as error
@@ -45,13 +45,17 @@ impl<X: Xfer> OpImpl<X> for TcpSendOp<'_> {
                     return Err(StackError::OpFailed(callback_len.into()));
                 }
 
-                // Validate callback length doesn't exceed remaining data in buffer
+                // Validate `total_sent` length doesn't exceed remaining data in buffer
+                // It is possible that the WINC sends data in multiple iterations before
+                // `AsyncState::Done` is called from the callback, so use the `total_sent`
+                // field from `SentRequest` to check the sent data length instead of
+                // `callback_len`.
                 let remaining_in_buffer = self.data.len() - req.offset;
-                let validated_len = if callback_len as usize > remaining_in_buffer {
+                let validated_len = if req.total_sent as usize > remaining_in_buffer {
                     // Clamp to remaining data if callback reports more than possible
                     remaining_in_buffer
                 } else {
-                    callback_len as usize
+                    req.total_sent as usize
                 };
 
                 // Ensure validated_len fits in i16 for arithmetic

--- a/winc-rs/src/net_ops/udp_send.rs
+++ b/winc-rs/src/net_ops/udp_send.rs
@@ -59,7 +59,7 @@ impl<X: Xfer> OpImpl<X> for UdpSendOp<'_> {
 
         match op {
             ClientSocketOp::AsyncOp(AsyncOp::SendTo(req, Some(len)), AsyncState::Done) => {
-                // Validate callback length parameter
+                // Validate callback length parameter for error.
                 let callback_len = *len;
                 if callback_len < 0 {
                     // Negative length is invalid - treat as error
@@ -67,13 +67,17 @@ impl<X: Xfer> OpImpl<X> for UdpSendOp<'_> {
                     return Err(StackError::OpFailed(callback_len.into()));
                 }
 
-                // Validate callback length doesn't exceed remaining data in buffer
+                // Validate `total_sent` length doesn't exceed remaining data in buffer
+                // It is possible that the WINC sends data in multiple iterations before
+                // `AsyncState::Done` is called from the callback, so use the `total_sent`
+                // field from `SentRequest` to check the sent data length instead of
+                // `callback_len`.
                 let remaining_in_buffer = self.data.len() - req.offset;
-                let validated_len = if callback_len as usize > remaining_in_buffer {
+                let validated_len = if req.total_sent as usize > remaining_in_buffer {
                     // Clamp to remaining data if callback reports more than possible
                     remaining_in_buffer
                 } else {
-                    callback_len as usize
+                    req.total_sent as usize
                 };
 
                 // Update grand_total_sent using validated length


### PR DESCRIPTION
This PR includes the following fixes:
1. <ins>HIF header issue </ins> (#139): `HIF_HEADER_OFFSET` was incorrectly added to the offset value for different operations(TCP/UDP/Ethernet). This has now been fixed.
2. <ins>TCP/UDP multi-iteration send issue:</ins> When the WINC takes multiple iterations to send a single chunk of data, the TCP/UDP state machine uses the length value from the last iteration (via the callback) to validate the sent chunk. This value can be less than the total data sent, causing the same data to be sent multiple times with different offsets. This has now been fixed.

## Summary by Sourcery

Fix HIF header length/offset handling and correct TCP/UDP send completion validation for multi-iteration transmissions.

Bug Fixes:
- Correct HIF header packet length calculation and per-protocol data offsets so payloads are framed with the proper header size.
- Fix TCP send completion logic to validate the amount of data sent using the accumulated total instead of the last callback length, avoiding duplicated data on multi-iteration sends.
- Fix UDP send completion logic to validate the amount of data sent using the accumulated total instead of the last callback length, preventing repeated sends with incorrect offsets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected packet header length and offset handling for UDP, Ethernet, and internal framing.
  * Improved TCP and UDP send accounting to base completion on accumulated bytes across multi-chunk transfers, avoiding premature completion.

* **Tests**
  * Added unit tests validating chunked TCP and UDP send behavior with multi-part callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->