### PR TITLE
Stack Layer method for Non-Blocking Features with a Shared Codebase for Sync and Async

### DIFF
--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -1,7 +1,7 @@
-use super::AsyncClient;
-use super::StackError;
-use crate::manager::{BootMode, BootState, Credentials, Ssid, WifiChannel};
+use super::{AsyncClient, Handle, StackError};
+use crate::manager::{BootMode, BootState, Credentials, SocketOptions, Ssid, WifiChannel};
 use crate::net_ops::module::StationMode;
+use crate::stack::Stack;
 use crate::transfer::Xfer;
 
 impl<X: Xfer> AsyncClient<'_, X> {
@@ -69,6 +69,34 @@ impl<X: Xfer> AsyncClient<'_, X> {
     ) -> Result<(), StackError> {
         let mut op = StationMode::from_credentials(ssid, credentials, channel, save_credentials);
         self.poll_op(&mut op).await
+    }
+
+    /// Sets the specified socket option on the given socket.
+    ///
+    /// # Arguments
+    ///
+    /// * `socket` - A socket handle to configure.
+    /// * `option` - The socket option to apply.
+    ///
+    /// # Returns
+    ///
+    /// * `()` - If the socket option was successfully applied.
+    /// * `StackError` - If an error occurs while applying the socket option.
+    pub fn set_socket_option(
+        &mut self,
+        socket: &Handle,
+        option: &SocketOptions,
+    ) -> Result<(), StackError> {
+        let mut manager = self
+            .manager
+            .try_borrow_mut()
+            .map_err(|_| StackError::ResourceBusy)?;
+        let mut callbacks = self
+            .callbacks
+            .try_borrow_mut()
+            .map_err(|_| StackError::ResourceBusy)?;
+        let mut stack = Stack::new(&mut manager, &mut callbacks);
+        stack.set_socket_option(socket, option)
     }
 }
 

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -4,16 +4,12 @@ use embedded_nal::nb;
 
 use crate::manager::{
     AccessPoint, AuthType, BootMode, BootState, Credentials, FirmwareInfo, HostName, IPConf,
-    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, TcpSockOpts, UdpSockOpts,
-    WifiChannel,
+    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, WifiChannel,
 };
 
 use crate::net_ops::module::StationMode;
 
-#[cfg(feature = "ssl")]
-use crate::manager::{SslSockConfig, SslSockOpts};
-
-use crate::stack::{sock_holder::SocketStore, socket_callbacks::WifiModuleState};
+use crate::stack::{socket_callbacks::WifiModuleState, Stack};
 
 use super::{Handle, PingResult, StackError, WincClient, Xfer};
 
@@ -464,58 +460,8 @@ impl<X: Xfer> WincClient<'_, X> {
         socket: &Handle,
         option: &SocketOptions,
     ) -> Result<(), StackError> {
-        match option {
-            SocketOptions::Udp(opts) => {
-                let (sock, _) = self
-                    .callbacks
-                    .udp_sockets
-                    .get(*socket)
-                    .ok_or(StackError::SocketNotFound)?;
-
-                if let UdpSockOpts::ReceiveTimeout(timeout) = opts {
-                    // Receive timeout are handled by winc stack not by module.
-                    sock.set_recv_timeout(*timeout);
-                } else {
-                    self.manager.send_setsockopt(*sock, opts)?;
-                }
-            }
-
-            SocketOptions::Tcp(opts) => {
-                let (sock, _) = self
-                    .callbacks
-                    .tcp_sockets
-                    .get(*socket)
-                    .ok_or(StackError::SocketNotFound)?;
-
-                match opts {
-                    #[cfg(feature = "ssl")]
-                    TcpSockOpts::Ssl(ssl_opts) => {
-                        match *ssl_opts {
-                            SslSockOpts::SetSni(_) => {
-                                self.manager.send_ssl_setsockopt(*sock, ssl_opts)?;
-                            }
-                            SslSockOpts::Config(cfg, en) => {
-                                if cfg == SslSockConfig::EnableSSL && en {
-                                    if (sock.get_ssl_cfg() & u8::from(cfg)) == cfg.into() {
-                                        return Ok(());
-                                    } else {
-                                        self.manager.send_ssl_sock_create(*sock)?;
-                                    }
-                                }
-                                // Set the SSL flags
-                                sock.set_ssl_cfg(cfg.into(), en);
-                            }
-                        }
-                    }
-                    TcpSockOpts::ReceiveTimeout(timeout) => {
-                        // Receive timeout are handled by winc stack not by module.
-                        sock.set_recv_timeout(*timeout);
-                    }
-                }
-            }
-        }
-
-        Ok(())
+        let mut stack = Stack::new(&mut self.manager, &mut self.callbacks);
+        stack.set_socket_option(socket, option)
     }
 
     /// Retrieves the MAC address from the WINC network interface.
@@ -543,6 +489,7 @@ mod tests {
     use crate::client::{test_shared::*, SocketCallbacks};
     use crate::errors::CommError as Error;
     use crate::manager::{Bssid, EventListener, PingError, Ssid, WifiConnError, WifiConnState};
+    use crate::stack::sock_holder::SocketStore;
     use crate::{ConnectionInfo, Credentials, S8Password, S8Username, WifiChannel, WpaKey};
     #[cfg(feature = "wep")]
     use crate::{WepKey, WepKeyIndex};

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -1,16 +1,19 @@
 use crate::errors::CommError as Error;
-use crate::net_ops::op::OpImpl;
 
 use embedded_nal::nb;
 
 use crate::manager::{
     AccessPoint, AuthType, BootMode, BootState, Credentials, FirmwareInfo, HostName, IPConf,
-    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, WifiChannel,
+    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, TcpSockOpts, UdpSockOpts,
+    WifiChannel,
 };
 
-use crate::net_ops::module::{SocketOptionOp, StationMode};
+use crate::net_ops::module::StationMode;
 
-use crate::stack::socket_callbacks::WifiModuleState;
+#[cfg(feature = "ssl")]
+use crate::manager::{SslSockConfig, SslSockOpts};
+
+use crate::stack::{sock_holder::SocketStore, socket_callbacks::WifiModuleState};
 
 use super::{Handle, PingResult, StackError, WincClient, Xfer};
 
@@ -461,13 +464,58 @@ impl<X: Xfer> WincClient<'_, X> {
         socket: &Handle,
         option: &SocketOptions,
     ) -> Result<(), StackError> {
-        let mut opts = SocketOptionOp::new(socket, option);
-        let result = opts.poll_impl(&mut self.manager, &mut self.callbacks)?;
-        if let Some(result) = result {
-            return Ok(result);
+        match option {
+            SocketOptions::Udp(opts) => {
+                let (sock, _) = self
+                    .callbacks
+                    .udp_sockets
+                    .get(*socket)
+                    .ok_or(StackError::SocketNotFound)?;
+
+                if let UdpSockOpts::ReceiveTimeout(timeout) = opts {
+                    // Receive timeout are handled by winc stack not by module.
+                    sock.set_recv_timeout(*timeout);
+                } else {
+                    self.manager.send_setsockopt(*sock, opts)?;
+                }
+            }
+
+            SocketOptions::Tcp(opts) => {
+                let (sock, _) = self
+                    .callbacks
+                    .tcp_sockets
+                    .get(*socket)
+                    .ok_or(StackError::SocketNotFound)?;
+
+                match opts {
+                    #[cfg(feature = "ssl")]
+                    TcpSockOpts::Ssl(ssl_opts) => {
+                        match *ssl_opts {
+                            SslSockOpts::SetSni(_) => {
+                                self.manager.send_ssl_setsockopt(*sock, ssl_opts)?;
+                            }
+                            SslSockOpts::Config(cfg, en) => {
+                                if cfg == SslSockConfig::EnableSSL && en {
+                                    if (sock.get_ssl_cfg() & u8::from(cfg)) == cfg.into() {
+                                        return Ok(());
+                                    } else {
+                                        self.manager.send_ssl_sock_create(*sock)?;
+                                    }
+                                }
+                                // Set the SSL flags
+                                sock.set_ssl_cfg(cfg.into(), en);
+                            }
+                        }
+                    }
+                    TcpSockOpts::ReceiveTimeout(timeout) => {
+                        // Receive timeout are handled by winc stack not by module.
+                        sock.set_recv_timeout(*timeout);
+                    }
+                }
+            }
         }
 
-        Err(StackError::Unexpected)
+        Ok(())
     }
 
     /// Retrieves the MAC address from the WINC network interface.
@@ -495,7 +543,6 @@ mod tests {
     use crate::client::{test_shared::*, SocketCallbacks};
     use crate::errors::CommError as Error;
     use crate::manager::{Bssid, EventListener, PingError, Ssid, WifiConnError, WifiConnState};
-    use crate::stack::sock_holder::SocketStore;
     use crate::{ConnectionInfo, Credentials, S8Password, S8Username, WifiChannel, WpaKey};
     #[cfg(feature = "wep")]
     use crate::{WepKey, WepKeyIndex};

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -1,19 +1,16 @@
 use crate::errors::CommError as Error;
+use crate::net_ops::op::OpImpl;
 
 use embedded_nal::nb;
 
 use crate::manager::{
     AccessPoint, AuthType, BootMode, BootState, Credentials, FirmwareInfo, HostName, IPConf,
-    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, TcpSockOpts, UdpSockOpts,
-    WifiChannel,
+    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, WifiChannel,
 };
 
-use crate::net_ops::module::StationMode;
+use crate::net_ops::module::{SocketOptionOp, StationMode};
 
-#[cfg(feature = "ssl")]
-use crate::manager::{SslSockConfig, SslSockOpts};
-
-use crate::stack::{sock_holder::SocketStore, socket_callbacks::WifiModuleState};
+use crate::stack::socket_callbacks::WifiModuleState;
 
 use super::{Handle, PingResult, StackError, WincClient, Xfer};
 
@@ -464,58 +461,13 @@ impl<X: Xfer> WincClient<'_, X> {
         socket: &Handle,
         option: &SocketOptions,
     ) -> Result<(), StackError> {
-        match option {
-            SocketOptions::Udp(opts) => {
-                let (sock, _) = self
-                    .callbacks
-                    .udp_sockets
-                    .get(*socket)
-                    .ok_or(StackError::SocketNotFound)?;
-
-                if let UdpSockOpts::ReceiveTimeout(timeout) = opts {
-                    // Receive timeout are handled by winc stack not by module.
-                    sock.set_recv_timeout(*timeout);
-                } else {
-                    self.manager.send_setsockopt(*sock, opts)?;
-                }
-            }
-
-            SocketOptions::Tcp(opts) => {
-                let (sock, _) = self
-                    .callbacks
-                    .tcp_sockets
-                    .get(*socket)
-                    .ok_or(StackError::SocketNotFound)?;
-
-                match opts {
-                    #[cfg(feature = "ssl")]
-                    TcpSockOpts::Ssl(ssl_opts) => {
-                        match *ssl_opts {
-                            SslSockOpts::SetSni(_) => {
-                                self.manager.send_ssl_setsockopt(*sock, ssl_opts)?;
-                            }
-                            SslSockOpts::Config(cfg, en) => {
-                                if cfg == SslSockConfig::EnableSSL && en {
-                                    if (sock.get_ssl_cfg() & u8::from(cfg)) == cfg.into() {
-                                        return Ok(());
-                                    } else {
-                                        self.manager.send_ssl_sock_create(*sock)?;
-                                    }
-                                }
-                                // Set the SSL flags
-                                sock.set_ssl_cfg(cfg.into(), en);
-                            }
-                        }
-                    }
-                    TcpSockOpts::ReceiveTimeout(timeout) => {
-                        // Receive timeout are handled by winc stack not by module.
-                        sock.set_recv_timeout(*timeout);
-                    }
-                }
-            }
+        let mut opts = SocketOptionOp::new(socket, option);
+        let result = opts.poll_impl(&mut self.manager, &mut self.callbacks)?;
+        if let Some(result) = result {
+            return Ok(result);
         }
 
-        Ok(())
+        Err(StackError::Unexpected)
     }
 
     /// Retrieves the MAC address from the WINC network interface.
@@ -543,6 +495,7 @@ mod tests {
     use crate::client::{test_shared::*, SocketCallbacks};
     use crate::errors::CommError as Error;
     use crate::manager::{Bssid, EventListener, PingError, Ssid, WifiConnError, WifiConnState};
+    use crate::stack::sock_holder::SocketStore;
     use crate::{ConnectionInfo, Credentials, S8Password, S8Username, WifiChannel, WpaKey};
     #[cfg(feature = "wep")]
     use crate::{WepKey, WepKeyIndex};

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -1,13 +1,23 @@
-#[cfg(feature = "flash-rw")]
-use crate::manager::BootMode;
-use crate::manager::{BootState, Credentials, Manager, Ssid};
+use crate::manager::{BootState, Credentials, Manager, Ssid, TcpSockOpts, UdpSockOpts};
 use crate::net_ops::op::OpImpl;
+use crate::stack::sock_holder::SocketStore;
 use crate::stack::socket_callbacks::{SocketCallbacks, WifiModuleState};
 use crate::transfer::Xfer;
-use crate::{StackError, WifiChannel};
+use crate::{Handle, SocketOptions, StackError, WifiChannel};
+
+#[cfg(feature = "ssl")]
+use crate::manager::{SslSockConfig, SslSockOpts};
+
+#[cfg(feature = "flash-rw")]
+use crate::manager::BootMode;
 
 // 1 minute max, if no other delays are added
 const AP_CONNECT_TIMEOUT_MILLISECONDS: u32 = 60_000;
+
+pub(crate) struct SocketOptionOp<'a> {
+    socket: &'a Handle,
+    socket_options: &'a SocketOptions,
+}
 
 pub(crate) struct StationMode<'a> {
     ssid: Option<&'a Ssid>,
@@ -15,6 +25,76 @@ pub(crate) struct StationMode<'a> {
     channel: WifiChannel,
     save_credentials: bool,
     use_defaults: bool,
+}
+
+impl<'a> SocketOptionOp<'a> {
+    pub fn new(socket: &'a Handle, options: &'a SocketOptions) -> Self {
+        Self {
+            socket,
+            socket_options: options,
+        }
+    }
+}
+
+impl<X: Xfer> OpImpl<X> for SocketOptionOp<'_> {
+    type Output = ();
+    type Error = StackError;
+
+    fn poll_impl(
+        &mut self,
+        manager: &mut crate::manager::Manager<X>,
+        callbacks: &mut crate::stack::socket_callbacks::SocketCallbacks,
+    ) -> Result<Option<Self::Output>, Self::Error> {
+        match self.socket_options {
+            SocketOptions::Udp(opts) => {
+                let (sock, _) = callbacks
+                    .udp_sockets
+                    .get(*self.socket)
+                    .ok_or(StackError::SocketNotFound)?;
+
+                if let UdpSockOpts::ReceiveTimeout(timeout) = opts {
+                    // Receive timeout are handled by winc stack not by module.
+                    sock.set_recv_timeout(*timeout);
+                } else {
+                    manager.send_setsockopt(*sock, opts)?;
+                }
+            }
+
+            SocketOptions::Tcp(opts) => {
+                let (sock, _) = callbacks
+                    .tcp_sockets
+                    .get(*self.socket)
+                    .ok_or(StackError::SocketNotFound)?;
+
+                match opts {
+                    #[cfg(feature = "ssl")]
+                    TcpSockOpts::Ssl(ssl_opts) => {
+                        match *ssl_opts {
+                            SslSockOpts::SetSni(_) => {
+                                manager.send_ssl_setsockopt(*sock, ssl_opts)?;
+                            }
+                            SslSockOpts::Config(cfg, en) => {
+                                if cfg == SslSockConfig::EnableSSL && en {
+                                    if (sock.get_ssl_cfg() & u8::from(cfg)) == cfg.into() {
+                                        return Ok(Some(()));
+                                    } else {
+                                        manager.send_ssl_sock_create(*sock)?;
+                                    }
+                                }
+                                // Set the SSL flags
+                                sock.set_ssl_cfg(cfg.into(), en);
+                            }
+                        }
+                    }
+                    TcpSockOpts::ReceiveTimeout(timeout) => {
+                        // Receive timeout are handled by winc stack not by module.
+                        sock.set_recv_timeout(*timeout);
+                    }
+                }
+            }
+        }
+        Ok(Some(()))
+    }
 }
 
 impl<'a> StationMode<'a> {

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -1,23 +1,13 @@
-use crate::manager::{BootState, Credentials, Manager, Ssid, TcpSockOpts, UdpSockOpts};
-use crate::net_ops::op::OpImpl;
-use crate::stack::sock_holder::SocketStore;
-use crate::stack::socket_callbacks::{SocketCallbacks, WifiModuleState};
-use crate::transfer::Xfer;
-use crate::{Handle, SocketOptions, StackError, WifiChannel};
-
-#[cfg(feature = "ssl")]
-use crate::manager::{SslSockConfig, SslSockOpts};
-
 #[cfg(feature = "flash-rw")]
 use crate::manager::BootMode;
+use crate::manager::{BootState, Credentials, Manager, Ssid};
+use crate::net_ops::op::OpImpl;
+use crate::stack::socket_callbacks::{SocketCallbacks, WifiModuleState};
+use crate::transfer::Xfer;
+use crate::{StackError, WifiChannel};
 
 // 1 minute max, if no other delays are added
 const AP_CONNECT_TIMEOUT_MILLISECONDS: u32 = 60_000;
-
-pub(crate) struct SocketOptionOp<'a> {
-    socket: &'a Handle,
-    socket_options: &'a SocketOptions,
-}
 
 pub(crate) struct StationMode<'a> {
     ssid: Option<&'a Ssid>,
@@ -25,76 +15,6 @@ pub(crate) struct StationMode<'a> {
     channel: WifiChannel,
     save_credentials: bool,
     use_defaults: bool,
-}
-
-impl<'a> SocketOptionOp<'a> {
-    pub fn new(socket: &'a Handle, options: &'a SocketOptions) -> Self {
-        Self {
-            socket,
-            socket_options: options,
-        }
-    }
-}
-
-impl<X: Xfer> OpImpl<X> for SocketOptionOp<'_> {
-    type Output = ();
-    type Error = StackError;
-
-    fn poll_impl(
-        &mut self,
-        manager: &mut crate::manager::Manager<X>,
-        callbacks: &mut crate::stack::socket_callbacks::SocketCallbacks,
-    ) -> Result<Option<Self::Output>, Self::Error> {
-        match self.socket_options {
-            SocketOptions::Udp(opts) => {
-                let (sock, _) = callbacks
-                    .udp_sockets
-                    .get(*self.socket)
-                    .ok_or(StackError::SocketNotFound)?;
-
-                if let UdpSockOpts::ReceiveTimeout(timeout) = opts {
-                    // Receive timeout are handled by winc stack not by module.
-                    sock.set_recv_timeout(*timeout);
-                } else {
-                    manager.send_setsockopt(*sock, opts)?;
-                }
-            }
-
-            SocketOptions::Tcp(opts) => {
-                let (sock, _) = callbacks
-                    .tcp_sockets
-                    .get(*self.socket)
-                    .ok_or(StackError::SocketNotFound)?;
-
-                match opts {
-                    #[cfg(feature = "ssl")]
-                    TcpSockOpts::Ssl(ssl_opts) => {
-                        match *ssl_opts {
-                            SslSockOpts::SetSni(_) => {
-                                manager.send_ssl_setsockopt(*sock, ssl_opts)?;
-                            }
-                            SslSockOpts::Config(cfg, en) => {
-                                if cfg == SslSockConfig::EnableSSL && en {
-                                    if (sock.get_ssl_cfg() & u8::from(cfg)) == cfg.into() {
-                                        return Ok(Some(()));
-                                    } else {
-                                        manager.send_ssl_sock_create(*sock)?;
-                                    }
-                                }
-                                // Set the SSL flags
-                                sock.set_ssl_cfg(cfg.into(), en);
-                            }
-                        }
-                    }
-                    TcpSockOpts::ReceiveTimeout(timeout) => {
-                        // Receive timeout are handled by winc stack not by module.
-                        sock.set_recv_timeout(*timeout);
-                    }
-                }
-            }
-        }
-        Ok(Some(()))
-    }
 }
 
 impl<'a> StationMode<'a> {

--- a/winc-rs/src/stack.rs
+++ b/winc-rs/src/stack.rs
@@ -7,26 +7,20 @@ pub mod stack_error;
 use crate::socket::Socket;
 use socket_callbacks::{ClientSocketOp, Handle};
 
-#[cfg(feature = "async")]
 use crate::manager::{Manager, SocketOptions, TcpSockOpts, UdpSockOpts};
-#[cfg(all(feature = "ssl", feature = "async"))]
+#[cfg(feature = "ssl")]
 use crate::manager::{SslSockConfig, SslSockOpts};
-#[cfg(feature = "async")]
 use crate::transfer::Xfer;
-#[cfg(feature = "async")]
 use sock_holder::SocketStore;
-#[cfg(feature = "async")]
 use socket_callbacks::SocketCallbacks;
 
 pub use stack_error::StackError;
 
-#[cfg(feature = "async")]
 pub(crate) struct Stack<'a, X: Xfer> {
     manager: &'a mut Manager<X>,
     callbacks: &'a mut SocketCallbacks,
 }
 
-#[cfg(feature = "async")]
 impl<'a, X: Xfer> Stack<'a, X> {
     pub(crate) fn new(manager: &'a mut Manager<X>, callbacks: &'a mut SocketCallbacks) -> Self {
         Self { manager, callbacks }

--- a/winc-rs/src/stack.rs
+++ b/winc-rs/src/stack.rs
@@ -5,7 +5,88 @@ pub mod socket_callbacks;
 pub mod stack_error;
 
 use crate::socket::Socket;
-//pub use sock_holder::SockHolder;
-pub use socket_callbacks::ClientSocketOp;
-use socket_callbacks::Handle;
+use socket_callbacks::{ClientSocketOp, Handle};
+
+#[cfg(feature = "async")]
+use crate::manager::{Manager, SocketOptions, TcpSockOpts, UdpSockOpts};
+#[cfg(all(feature = "ssl", feature = "async"))]
+use crate::manager::{SslSockConfig, SslSockOpts};
+#[cfg(feature = "async")]
+use crate::transfer::Xfer;
+#[cfg(feature = "async")]
+use sock_holder::SocketStore;
+#[cfg(feature = "async")]
+use socket_callbacks::SocketCallbacks;
+
 pub use stack_error::StackError;
+
+#[cfg(feature = "async")]
+pub(crate) struct Stack<'a, X: Xfer> {
+    manager: &'a mut Manager<X>,
+    callbacks: &'a mut SocketCallbacks,
+}
+
+#[cfg(feature = "async")]
+impl<'a, X: Xfer> Stack<'a, X> {
+    pub(crate) fn new(manager: &'a mut Manager<X>, callbacks: &'a mut SocketCallbacks) -> Self {
+        Self { manager, callbacks }
+    }
+    pub(crate) fn set_socket_option(
+        &mut self,
+        socket: &Handle,
+        option: &SocketOptions,
+    ) -> Result<(), StackError> {
+        match option {
+            SocketOptions::Udp(opts) => {
+                let (sock, _) = self
+                    .callbacks
+                    .udp_sockets
+                    .get(*socket)
+                    .ok_or(StackError::SocketNotFound)?;
+
+                if let UdpSockOpts::ReceiveTimeout(timeout) = opts {
+                    // Receive timeout are handled by winc stack not by module.
+                    sock.set_recv_timeout(*timeout);
+                } else {
+                    self.manager.send_setsockopt(*sock, opts)?;
+                }
+            }
+
+            SocketOptions::Tcp(opts) => {
+                let (sock, _) = self
+                    .callbacks
+                    .tcp_sockets
+                    .get(*socket)
+                    .ok_or(StackError::SocketNotFound)?;
+
+                match opts {
+                    #[cfg(feature = "ssl")]
+                    TcpSockOpts::Ssl(ssl_opts) => {
+                        match *ssl_opts {
+                            SslSockOpts::SetSni(_) => {
+                                self.manager.send_ssl_setsockopt(*sock, ssl_opts)?;
+                            }
+                            SslSockOpts::Config(cfg, en) => {
+                                if cfg == SslSockConfig::EnableSSL && en {
+                                    if (sock.get_ssl_cfg() & u8::from(cfg)) == cfg.into() {
+                                        return Ok(());
+                                    } else {
+                                        self.manager.send_ssl_sock_create(*sock)?;
+                                    }
+                                }
+                                // Set the SSL flags
+                                sock.set_ssl_cfg(cfg.into(), en);
+                            }
+                        }
+                    }
+                    TcpSockOpts::ReceiveTimeout(timeout) => {
+                        // Receive timeout are handled by winc stack not by module.
+                        sock.set_recv_timeout(*timeout);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/winc-rs/src/stack/stack_error.rs
+++ b/winc-rs/src/stack/stack_error.rs
@@ -56,6 +56,9 @@ pub enum StackError {
     #[cfg(feature = "async")]
     /// Too many concurrent async operations (waker array full)
     TooManyWakers,
+    /// If acquiring resources such as a manager or callback fails.
+    #[cfg(feature = "async")]
+    ResourceBusy,
 }
 
 impl From<core::convert::Infallible> for StackError {
@@ -141,6 +144,8 @@ impl core::fmt::Display for StackError {
             Self::OtaFail(err) => write!(f, "Ota failure: {:?}", err),
             #[cfg(feature = "async")]
             Self::TooManyWakers => write!(f, "Too many concurrent async operations"),
+            #[cfg(feature = "async")]
+            Self::ResourceBusy => write!(f, "Resources busy"),
         }
     }
 }


### PR DESCRIPTION
This PR implements `Stack` layer in `stack.rs` to support non-blocking features in async while sharing a common codebase for both sync and async. Another approach is covered in PR #143 .

For demonstration, a method to set `Socket Options` is implemented.

**This PR is for discussion only and should not be merged.**

## Summary by Sourcery

Introduce shared socket option handling abstraction usable by both sync and async clients.

New Features:
- Add a Stack abstraction for async builds to centralize socket option configuration using shared logic.
- Expose a set_socket_option API on the async client that uses the shared Stack logic to configure UDP/TCP (including SSL) socket options.

Enhancements:
- Refactor socket option handling into a reusable SocketOptionOp implementing OpImpl for the sync client.
- Extend StackError with a ResourceBusy variant to represent contention when borrowing shared async resources.