### PR TITLE
Reduce clock speed of SPI for sync examples

### DIFF
--- a/feather/src/init.rs
+++ b/feather/src/init.rs
@@ -57,8 +57,8 @@ use usb_logging::setup_usb_device;
 #[cfg(feature = "serial-usb")]
 pub use usb_logging::UsbSerial;
 
-// Set SPI bus to 8 Mhz, about as fast as it goes
-const SPI_MHZ: u32 = 8;
+// Set SPI bus to 4 Mhz, about as fast as it goes
+const SPI_MHZ: u32 = 4;
 const I2C_KHZ: u32 = 400;
 
 // Chip reset sequence timing. TODO: Shorten those as much as

--- a/feather/src/shared/spi_stream.rs
+++ b/feather/src/shared/spi_stream.rs
@@ -61,7 +61,8 @@ impl<CS: OutputPin, Spi: SpiBus> SpiStream<CS, Spi> {
 
             let result = self.spi.transfer_in_place(buf);
             cortex_m::asm::delay(self.wait_cycles);
-            if end {
+
+            if end || result.is_err() {
                 // Pin errors are Infallible, safe to discard
                 OutputPin::set_high(&mut cs).ok();
             }

--- a/feather/src/shared/spi_stream.rs
+++ b/feather/src/shared/spi_stream.rs
@@ -58,18 +58,19 @@ impl<CS: OutputPin, Spi: SpiBus> SpiStream<CS, Spi> {
                 OutputPin::set_low(&mut cs).ok();
                 cortex_m::asm::delay(self.wait_cycles);
             }
+
             let result = self.spi.transfer_in_place(buf);
-            if let Err(e) = result {
-                self.cs.get_or_insert(cs);
-                return Err(e);
-            }
             cortex_m::asm::delay(self.wait_cycles);
             if end {
                 // Pin errors are Infallible, safe to discard
                 OutputPin::set_high(&mut cs).ok();
             }
 
+            // Restore CS before returning
             self.cs.get_or_insert(cs);
+            // propagate error after restoring CS
+            result?;
+
             #[cfg(feature = "defmt")]
             defmt::trace!("recv: {=[u8]:#x}", buf);
         }

--- a/feather_async/src/shared/spi_stream.rs
+++ b/feather_async/src/shared/spi_stream.rs
@@ -41,13 +41,18 @@ impl<CS: AnyPin, Spi: SpiBus> SpiStream<CS, Spi> {
                 pin.set_low().ok();
                 cortex_m::asm::delay(self.wait_cycles);
             }
-            self.spi.transfer_in_place(buf)?;
+
+            let result = self.spi.transfer_in_place(buf);
             cortex_m::asm::delay(self.wait_cycles);
             if end {
                 pin.set_high().ok();
             }
 
+            // Restore CS before returning
             self.cs.get_or_insert(pin.into_mode().into());
+            // propagate error after restoring CS
+            result?;
+
             trace!("recv: {=[u8]:#x}", buf);
         }
         Ok(())

--- a/feather_async/src/shared/spi_stream.rs
+++ b/feather_async/src/shared/spi_stream.rs
@@ -44,7 +44,8 @@ impl<CS: AnyPin, Spi: SpiBus> SpiStream<CS, Spi> {
 
             let result = self.spi.transfer_in_place(buf);
             cortex_m::asm::delay(self.wait_cycles);
-            if end {
+
+            if end || result.is_err() {
                 pin.set_high().ok();
             }
 


### PR DESCRIPTION
This PR reduces the SPI clock speed for sync examples back to 4 MHz, as higher speeds cause the provisioning example to break after several polling iterations for new events `dispatch_events`.

This PR also updates the SPI transfer functions to set the CS line back to high after a transfer is complete, regardless of whether it succeeds or fails.

## Summary by Sourcery

Reduce SPI bus speed and ensure chip select is restored after SPI transfers, even on error.

Bug Fixes:
- Ensure SPI chip select line is driven high after synchronous SPI transfers complete, regardless of success or failure.
- Ensure SPI chip select line is driven high after asynchronous SPI transfers complete, regardless of success or failure.
- Mitigate provisioning failures by lowering the SPI bus frequency from 8 MHz to 4 MHz for sync examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI transfer error handling to ensure chip select pins are properly restored even during communication failures.
  * Enhanced error recovery in both synchronous and asynchronous SPI operations while maintaining consistent pin state.

* **Performance**
  * Adjusted SPI clock frequency for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->