### PR TITLE
Support for Provisioning Mode in Async Client.

### DIFF
--- a/feather/examples/provisioning.rs
+++ b/feather/examples/provisioning.rs
@@ -49,19 +49,19 @@ fn program() -> Result<(), StackError> {
         }
         // Configure the access point with WPA/WPA2 security using the provided SSID and password.
         let access_point = AccessPoint::wpa(&ap_ssid, &ap_password);
-        // Start the provising mode.
+        // Start the provisioning mode.
         info!(
             "Starting Provisioning Mode for {} minutes",
             DEFAULT_PROVISIONING_TIMEOUT_IN_MINS
         );
-        let result = nb::block!(stack.provisioning_mode(
+        let result = nb::block!(stack.start_provisioning_mode(
             &access_point,
             &hostname,
             true,
             DEFAULT_PROVISIONING_TIMEOUT_IN_MINS,
         ));
 
-        // Check for provisioning information is receieved for 15 minutes.
+        // Check for provisioning information is received for 15 minutes.
         match result {
             Ok(info) => {
                 info!("Credentials received from provisioning; connecting to access point.");
@@ -77,7 +77,8 @@ fn program() -> Result<(), StackError> {
             Err(err) => {
                 if err == StackError::GeneralTimeout {
                     error!(
-                        "No information was received for 15 minutes. Stopping provisioning mode."
+                        "No information was received for {} minutes. Stopping provisioning mode.",
+                        DEFAULT_PROVISIONING_TIMEOUT_IN_MINS
                     );
                     stack.stop_provisioning_mode()?;
                 } else {

--- a/feather_async/examples/provisioning.rs
+++ b/feather_async/examples/provisioning.rs
@@ -64,7 +64,7 @@ async fn program() -> Result<(), AppError> {
                     "No information was received for {} minutes. Stopping provisioning mode.",
                     DEFAULT_PROVISIONING_TIMEOUT_IN_MINS
                 );
-                //stack.stop_provisioning_mode()?; // Todo
+                stack.stop_provisioning_mode()?;
             } else {
                 defmt::error!("Provisioning Failed");
             }

--- a/feather_async/examples/provisioning.rs
+++ b/feather_async/examples/provisioning.rs
@@ -1,0 +1,92 @@
+//! Provisioning Mode
+//!
+
+#![no_main]
+#![no_std]
+
+use embassy_time::Timer;
+use feather_async::hal::ehal::digital::OutputPin;
+use feather_async::init::init;
+use feather_async::shared::{AppError, SpiStream};
+use wincwifi::{AccessPoint, AsyncClient, HostName, Ssid, StackError, WifiChannel, WpaKey};
+
+const DEFAULT_TEST_SSID: &str = "winc_network";
+const DEFAULT_TEST_PASSWORD: &str = "password";
+const DEFAULT_TEST_HOSTNAME: &str = "admin";
+const DEFAULT_PROVISIONING_TIMEOUT_IN_MINS: u32 = 15;
+
+async fn program() -> Result<(), AppError> {
+    // init the feather board.
+    let ini = init().await?;
+    defmt::info!("Hello, Winc Provisioning");
+    let mut red_led = ini.red_led;
+
+    let ap_ssid = Ssid::from(option_env!("TEST_AP_SSID").unwrap_or(DEFAULT_TEST_SSID)).unwrap();
+    let ap_password =
+        WpaKey::from(option_env!("TEST_AP_PASSWORD").unwrap_or(DEFAULT_TEST_PASSWORD)).unwrap();
+    let hostname =
+        HostName::from(option_env!("TEST_AP_DNS").unwrap_or(DEFAULT_TEST_HOSTNAME)).unwrap();
+
+    let mut stack = AsyncClient::new(SpiStream::new(ini.cs, ini.spi));
+
+    defmt::info!("Initializing module");
+    stack.start_wifi_module().await?;
+
+    // Configure the access point with WPA/WPA2 security using the provided SSID and password.
+    let access_point = AccessPoint::wpa(&ap_ssid, &ap_password);
+    // Start the provisioning mode.
+    defmt::info!(
+        "Starting Provisioning Mode for {} minutes",
+        DEFAULT_PROVISIONING_TIMEOUT_IN_MINS
+    );
+    let result = stack
+        .start_provisioning_mode(
+            &access_point,
+            &hostname,
+            true,
+            DEFAULT_PROVISIONING_TIMEOUT_IN_MINS,
+        )
+        .await;
+
+    // Check for provisioning information is received for 15 minutes.
+    match result {
+        Ok(info) => {
+            defmt::info!("Credentials received from provisioning; connecting to access point.");
+            // Connect to access point.
+            stack
+                .connect_to_ap(&info.ssid, &info.key, WifiChannel::ChannelAll, false)
+                .await?;
+            defmt::info!("Connected to AP");
+        }
+        Err(err) => {
+            if err == StackError::GeneralTimeout {
+                defmt::error!(
+                    "No information was received for {} minutes. Stopping provisioning mode.",
+                    DEFAULT_PROVISIONING_TIMEOUT_IN_MINS
+                );
+                //stack.stop_provisioning_mode()?;
+            } else {
+                defmt::error!("Provisioning Failed");
+            }
+        }
+    }
+
+    loop {
+        Timer::after_millis(200).await;
+        red_led.set_high().unwrap();
+        Timer::after_millis(200).await;
+        red_led.set_low().unwrap();
+        stack.heartbeat()?;
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_s: embassy_executor::Spawner) -> ! {
+    if let Err(err) = program().await {
+        defmt::error!("Error: {}", err);
+        panic!("Error in main program");
+    } else {
+        defmt::info!("Good exit")
+    };
+    loop {}
+}

--- a/feather_async/examples/provisioning.rs
+++ b/feather_async/examples/provisioning.rs
@@ -64,7 +64,7 @@ async fn program() -> Result<(), AppError> {
                     "No information was received for {} minutes. Stopping provisioning mode.",
                     DEFAULT_PROVISIONING_TIMEOUT_IN_MINS
                 );
-                //stack.stop_provisioning_mode()?;
+                //stack.stop_provisioning_mode()?; // Todo
             } else {
                 defmt::error!("Provisioning Failed");
             }

--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -1,9 +1,9 @@
 use super::{AsyncClient, Handle, StackError};
 use crate::manager::{
     AccessPoint, BootMode, BootState, Credentials, FirmwareInfo, MacAddress, SocketOptions, Ssid,
-    WifiChannel,
+    WifiChannel, ProvisioningInfo, HostName
 };
-use crate::net_ops::module::{StationMode, SyncOp};
+use crate::net_ops::module::{ProvisioningMode, StationMode, SyncOp};
 use crate::transfer::Xfer;
 
 impl<X: Xfer> AsyncClient<'_, X> {
@@ -161,6 +161,28 @@ impl<X: Xfer> AsyncClient<'_, X> {
 
         op.retrieve_firmware_version()
     }
+
+    /// Starts the provisioning mode. This command is only applicable when the chip is
+    /// in station mode or unconnected.
+    /// 
+    /// * `hostname` - Device domain name. Must not include `.local`.
+    /// * `http_redirect` - Whether HTTP redirection is enabled.
+    /// * `timeout` - The timeout duration for provisioning, in minutes.
+    ///
+    /// # Returns
+    ///
+    /// * `ProvisioningInfo` - Wifi Credentials received from provisioning.
+    /// * `StackError` - If an error occurs while starting provisioning mode or receiving provisioning information.
+    pub async fn start_provisioning_mode<'a>(
+        &mut self,
+        ap: &'a AccessPoint<'a>,
+        hostname: &HostName,
+        http_redirect: bool,
+        timeout: u32,
+    ) -> Result<ProvisioningInfo, StackError> {
+        let mut op = ProvisioningMode::new(ap, hostname, http_redirect, timeout);
+        self.poll_op(&mut op).await
+    }
 }
 
 #[cfg(test)]
@@ -168,9 +190,11 @@ mod tests {
     use super::super::tests::make_test_client;
     use super::*;
     use crate::errors::CommError as Error;
-    use crate::manager::{EventListener, WifiConnError, WifiConnState, WpaKey};
-    use crate::stack::sock_holder::SocketStore;
-    use crate::stack::socket_callbacks::{SocketCallbacks, WifiModuleState};
+    use crate::manager::{EventListener, WifiConnError, WifiConnState, WpaKey, S8Password, S8Username, AuthType};
+    use crate::stack::{
+        sock_holder::SocketStore,
+        socket_callbacks::{SocketCallbacks, WifiModuleState}
+    };
     use core::net::Ipv4Addr;
     use macro_rules_attribute::apply;
     use smol_macros::test;
@@ -322,6 +346,153 @@ mod tests {
         let ap = AccessPoint {
             ssid: &ssid,
             key: key,
+            channel: WifiChannel::Channel1,
+            ssid_hidden: false,
+            ip: Ipv4Addr::new(192, 168, 1, 1),
+        };
+        let result = client.enable_access_point(&ap);
+
+        assert_eq!(result.err(), Some(StackError::InvalidParameters));
+    }
+    
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_open_success() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        // Should be empty for Open network.
+        let test_key = WpaKey::new();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::Open, true);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::Open);
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_wpa_success() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // wpa key for access point configuration.
+        let ap_key = WpaKey::from("wpa_key").unwrap();
+        // Access Point Configuration.
+        let ap = AccessPoint::wpa(&ap_ssid, &ap_key);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        let test_key = WpaKey::from("test_key").unwrap();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::WpaPSK, true);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::WpaPSK(test_key));
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[cfg(feature = "wep")]
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_wep_success() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // wep key for access point configuration.
+        let ap_key = WepKey::from("wep_key").unwrap();
+        // Wep key index
+        let wep_key_index = WepKeyIndex::Key1;
+        // Access Point Configuration.
+        let ap = AccessPoint::wep(&ap_ssid, &ap_key, wep_key_index);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        let test_key = WpaKey::from("test_wep_key").unwrap();
+        // Wep Key received from provisioning.
+        let test_wep_key = WepKey::from("test_wep_key").unwrap();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::WEP, true);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::Wep(test_wep_key, wep_key_index));
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_enterprise_fail() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // S802_1X Username for network credentials.
+        let s8_username = S8Username::from("username").unwrap();
+        // S802_1X Password for network credentials.
+        let s8_password = S8Password::from("password").unwrap();
+        // S802_1X network credentials.
+        let ap_key = Credentials::S802_1X(s8_username, s8_password);
+
+        // Access Point Configuration.
+        let ap = AccessPoint {
+            ssid: &ap_ssid,
+            key: ap_key,
             channel: WifiChannel::Channel1,
             ssid_hidden: false,
             ip: Ipv4Addr::new(192, 168, 1, 1),
@@ -561,5 +732,116 @@ mod tests {
         client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
         let result = client.get_firmware_version();
         assert_eq!(result.unwrap().chip_id, 0);
+
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error, StackError::InvalidParameters);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_invalid_state() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            // set the module state to connecting.
+            client.callbacks.borrow_mut().state = WifiModuleState::ConnectingToAp;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert_eq!(err, StackError::InvalidState);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_timeout() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1500)
+                .await
+        };
+
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert_eq!(err, StackError::GeneralTimeout);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_failed() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        // Should be empty for Open network.
+        let test_key = WpaKey::new();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::Open, false);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error, StackError::WincWifiFail(Error::Failed));
+        } else {
+            assert!(false);
+        }
     }
 }

--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -202,6 +202,9 @@ mod tests {
     #[cfg(feature = "ssl")]
     use crate::manager::SslSockConfig;
 
+    #[cfg(feature = "wep")]
+    use crate::{WepKey, WepKeyIndex};
+
     #[apply(test!)]
     async fn test_async_connect_to_saved_ap_invalid_state() {
         let mut client = make_test_client();
@@ -354,7 +357,7 @@ mod tests {
 
         assert_eq!(result.err(), Some(StackError::InvalidParameters));
     }
-    
+
     #[apply(test!)]
     async fn test_async_provisioning_mode_open_success() {
         // ssid for access point configuration.
@@ -497,9 +500,26 @@ mod tests {
             ssid_hidden: false,
             ip: Ipv4Addr::new(192, 168, 1, 1),
         };
-        let result = client.enable_access_point(&ap);
 
-        assert_eq!(result.err(), Some(StackError::InvalidParameters));
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error, StackError::InvalidParameters);
+        } else {
+            assert!(false);
+        }
     }
 
     #[test]
@@ -732,26 +752,6 @@ mod tests {
         client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
         let result = client.get_firmware_version();
         assert_eq!(result.unwrap().chip_id, 0);
-
-        // hostname for access point.
-        let hostname = HostName::from("admin").unwrap();
-
-        let result = {
-            // test client
-            let mut client = make_test_client();
-            // set the module state to unconnected.
-            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
-            client
-                .start_provisioning_mode(&ap, &hostname, false, 1)
-                .await
-        };
-
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert_eq!(error, StackError::InvalidParameters);
-        } else {
-            assert!(false);
-        }
     }
 
     #[apply(test!)]

--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -176,7 +176,7 @@ impl<X: Xfer> AsyncClient<'_, X> {
     pub async fn start_provisioning_mode<'a>(
         &mut self,
         ap: &'a AccessPoint<'a>,
-        hostname: &HostName,
+        hostname: &'a HostName,
         http_redirect: bool,
         timeout: u32,
     ) -> Result<ProvisioningInfo, StackError> {

--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -1,7 +1,7 @@
 use super::{AsyncClient, Handle, StackError};
 use crate::manager::{
-    AccessPoint, BootMode, BootState, Credentials, FirmwareInfo, MacAddress, SocketOptions, Ssid,
-    WifiChannel, ProvisioningInfo, HostName
+    AccessPoint, BootMode, BootState, Credentials, FirmwareInfo, HostName, MacAddress,
+    ProvisioningInfo, SocketOptions, Ssid, WifiChannel,
 };
 use crate::net_ops::module::{ProvisioningMode, StationMode, SyncOp};
 use crate::transfer::Xfer;
@@ -164,7 +164,10 @@ impl<X: Xfer> AsyncClient<'_, X> {
 
     /// Starts the provisioning mode. This command is only applicable when the chip is
     /// in station mode or unconnected.
-    /// 
+    ///
+    /// # Arguments
+    ///
+    /// * `ap` - An `AccessPoint` struct containing the SSID, password, and other network details.
     /// * `hostname` - Device domain name. Must not include `.local`.
     /// * `http_redirect` - Whether HTTP redirection is enabled.
     /// * `timeout` - The timeout duration for provisioning, in minutes.
@@ -190,10 +193,12 @@ mod tests {
     use super::super::tests::make_test_client;
     use super::*;
     use crate::errors::CommError as Error;
-    use crate::manager::{EventListener, WifiConnError, WifiConnState, WpaKey, S8Password, S8Username, AuthType};
+    use crate::manager::{
+        AuthType, EventListener, S8Password, S8Username, WifiConnError, WifiConnState, WpaKey,
+    };
     use crate::stack::{
         sock_holder::SocketStore,
-        socket_callbacks::{SocketCallbacks, WifiModuleState}
+        socket_callbacks::{SocketCallbacks, WifiModuleState},
     };
     use core::net::Ipv4Addr;
     use macro_rules_attribute::apply;
@@ -356,170 +361,6 @@ mod tests {
         let result = client.enable_access_point(&ap);
 
         assert_eq!(result.err(), Some(StackError::InvalidParameters));
-    }
-
-    #[apply(test!)]
-    async fn test_async_provisioning_mode_open_success() {
-        // ssid for access point configuration.
-        let ap_ssid = Ssid::from("ssid").unwrap();
-        // access point configuration.
-        let ap = AccessPoint::open(&ap_ssid);
-        // hostname for access point.
-        let hostname = HostName::from("admin").unwrap();
-        // ssid received from provisioning.
-        let test_ssid = Ssid::from("test_ssid").unwrap();
-        // Wpa key passed to provisioning callback.
-        // Should be empty for Open network.
-        let test_key = WpaKey::new();
-        // debug callback
-        let mut my_debug = |callbacks: &mut SocketCallbacks| {
-            callbacks.on_provisioning(test_ssid, test_key, AuthType::Open, true);
-        };
-
-        let result = {
-            // test client
-            let mut client = make_test_client();
-            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
-            // set the module state to unconnected.
-            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
-
-            client
-                .start_provisioning_mode(&ap, &hostname, false, 1)
-                .await
-        };
-
-        assert!(result.is_ok());
-        if let Ok(info) = result {
-            assert_eq!(info.key, Credentials::Open);
-            assert_eq!(info.ssid, test_ssid);
-        } else {
-            assert!(false);
-        }
-    }
-
-    #[apply(test!)]
-    async fn test_async_provisioning_mode_wpa_success() {
-        // ssid for access point configuration.
-        let ap_ssid = Ssid::from("ssid").unwrap();
-        // wpa key for access point configuration.
-        let ap_key = WpaKey::from("wpa_key").unwrap();
-        // Access Point Configuration.
-        let ap = AccessPoint::wpa(&ap_ssid, &ap_key);
-        // hostname for access point.
-        let hostname = HostName::from("admin").unwrap();
-        // ssid received from provisioning.
-        let test_ssid = Ssid::from("test_ssid").unwrap();
-        // Wpa key passed to provisioning callback.
-        let test_key = WpaKey::from("test_key").unwrap();
-        // debug callback
-        let mut my_debug = |callbacks: &mut SocketCallbacks| {
-            callbacks.on_provisioning(test_ssid, test_key, AuthType::WpaPSK, true);
-        };
-
-        let result = {
-            // test client
-            let mut client = make_test_client();
-            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
-            // set the module state to unconnected.
-            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
-
-            client
-                .start_provisioning_mode(&ap, &hostname, false, 1)
-                .await
-        };
-
-        assert!(result.is_ok());
-        if let Ok(info) = result {
-            assert_eq!(info.key, Credentials::WpaPSK(test_key));
-            assert_eq!(info.ssid, test_ssid);
-        } else {
-            assert!(false);
-        }
-    }
-
-    #[cfg(feature = "wep")]
-    #[apply(test!)]
-    async fn test_async_provisioning_mode_wep_success() {
-        // ssid for access point configuration.
-        let ap_ssid = Ssid::from("ssid").unwrap();
-        // wep key for access point configuration.
-        let ap_key = WepKey::from("wep_key").unwrap();
-        // Wep key index
-        let wep_key_index = WepKeyIndex::Key1;
-        // Access Point Configuration.
-        let ap = AccessPoint::wep(&ap_ssid, &ap_key, wep_key_index);
-        // hostname for access point.
-        let hostname = HostName::from("admin").unwrap();
-        // ssid received from provisioning.
-        let test_ssid = Ssid::from("test_ssid").unwrap();
-        // Wpa key passed to provisioning callback.
-        let test_key = WpaKey::from("test_wep_key").unwrap();
-        // Wep Key received from provisioning.
-        let test_wep_key = WepKey::from("test_wep_key").unwrap();
-        // debug callback
-        let mut my_debug = |callbacks: &mut SocketCallbacks| {
-            callbacks.on_provisioning(test_ssid, test_key, AuthType::WEP, true);
-        };
-
-        let result = {
-            // test client
-            let mut client = make_test_client();
-            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
-            // set the module state to unconnected.
-            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
-            client
-                .start_provisioning_mode(&ap, &hostname, false, 1)
-                .await
-        };
-
-        assert!(result.is_ok());
-        if let Ok(info) = result {
-            assert_eq!(info.key, Credentials::Wep(test_wep_key, wep_key_index));
-            assert_eq!(info.ssid, test_ssid);
-        } else {
-            assert!(false);
-        }
-    }
-
-    #[apply(test!)]
-    async fn test_async_provisioning_mode_enterprise_fail() {
-        // ssid for access point configuration.
-        let ap_ssid = Ssid::from("ssid").unwrap();
-        // S802_1X Username for network credentials.
-        let s8_username = S8Username::from("username").unwrap();
-        // S802_1X Password for network credentials.
-        let s8_password = S8Password::from("password").unwrap();
-        // S802_1X network credentials.
-        let ap_key = Credentials::S802_1X(s8_username, s8_password);
-
-        // Access Point Configuration.
-        let ap = AccessPoint {
-            ssid: &ap_ssid,
-            key: ap_key,
-            channel: WifiChannel::Channel1,
-            ssid_hidden: false,
-            ip: Ipv4Addr::new(192, 168, 1, 1),
-        };
-
-        // hostname for access point.
-        let hostname = HostName::from("admin").unwrap();
-
-        let result = {
-            // test client
-            let mut client = make_test_client();
-            // set the module state to unconnected.
-            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
-            client
-                .start_provisioning_mode(&ap, &hostname, false, 1)
-                .await
-        };
-
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert_eq!(error, StackError::InvalidParameters);
-        } else {
-            assert!(false);
-        }
     }
 
     #[test]
@@ -752,6 +593,170 @@ mod tests {
         client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
         let result = client.get_firmware_version();
         assert_eq!(result.unwrap().chip_id, 0);
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_open_success() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // access point configuration.
+        let ap = AccessPoint::open(&ap_ssid);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        // Should be empty for Open network.
+        let test_key = WpaKey::new();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::Open, true);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::Open);
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_wpa_success() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // wpa key for access point configuration.
+        let ap_key = WpaKey::from("wpa_key").unwrap();
+        // Access Point Configuration.
+        let ap = AccessPoint::wpa(&ap_ssid, &ap_key);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        let test_key = WpaKey::from("test_key").unwrap();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::WpaPSK, true);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::WpaPSK(test_key));
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[cfg(feature = "wep")]
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_wep_success() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // wep key for access point configuration.
+        let ap_key = WepKey::from("wep_key").unwrap();
+        // Wep key index
+        let wep_key_index = WepKeyIndex::Key1;
+        // Access Point Configuration.
+        let ap = AccessPoint::wep(&ap_ssid, &ap_key, wep_key_index);
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+        // ssid received from provisioning.
+        let test_ssid = Ssid::from("test_ssid").unwrap();
+        // Wpa key passed to provisioning callback.
+        let test_key = WpaKey::from("test_wep_key").unwrap();
+        // Wep Key received from provisioning.
+        let test_wep_key = WepKey::from("test_wep_key").unwrap();
+        // debug callback
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_provisioning(test_ssid, test_key, AuthType::WEP, true);
+        };
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_ok());
+        if let Ok(info) = result {
+            assert_eq!(info.key, Credentials::Wep(test_wep_key, wep_key_index));
+            assert_eq!(info.ssid, test_ssid);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[apply(test!)]
+    async fn test_async_provisioning_mode_enterprise_fail() {
+        // ssid for access point configuration.
+        let ap_ssid = Ssid::from("ssid").unwrap();
+        // S802_1X Username for network credentials.
+        let s8_username = S8Username::from("username").unwrap();
+        // S802_1X Password for network credentials.
+        let s8_password = S8Password::from("password").unwrap();
+        // S802_1X network credentials.
+        let ap_key = Credentials::S802_1X(s8_username, s8_password);
+
+        // Access Point Configuration.
+        let ap = AccessPoint {
+            ssid: &ap_ssid,
+            key: ap_key,
+            channel: WifiChannel::Channel1,
+            ssid_hidden: false,
+            ip: Ipv4Addr::new(192, 168, 1, 1),
+        };
+
+        // hostname for access point.
+        let hostname = HostName::from("admin").unwrap();
+
+        let result = {
+            // test client
+            let mut client = make_test_client();
+            // set the module state to unconnected.
+            client.callbacks.borrow_mut().state = WifiModuleState::Unconnected;
+            client
+                .start_provisioning_mode(&ap, &hostname, false, 1)
+                .await
+        };
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error, StackError::InvalidParameters);
+        } else {
+            assert!(false);
+        }
     }
 
     #[apply(test!)]

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -1,8 +1,8 @@
 use embedded_nal::nb;
 
 use crate::manager::{
-    AccessPoint, AuthType, BootMode, BootState, Credentials, FirmwareInfo, HostName, IPConf,
-    MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, WifiChannel,
+    AccessPoint, BootMode, BootState, Credentials, FirmwareInfo, HostName, IPConf, MacAddress,
+    ProvisioningInfo, ScanResult, SocketOptions, Ssid, WifiChannel,
 };
 
 use crate::net_ops::module::{ProvisioningMode, StationMode, SyncOp};
@@ -11,7 +11,7 @@ use crate::stack::socket_callbacks::WifiModuleState;
 
 use super::{Handle, PingResult, StackError, WincClient, Xfer};
 
-use crate::{error, info};
+use crate::info;
 
 // 5 seconds max, assuming no additional delays
 const AP_DISCONNECT_TIMEOUT_MILLISECONDS: u32 = 5_000;
@@ -426,7 +426,9 @@ mod tests {
     use super::*;
     use crate::client::{test_shared::*, SocketCallbacks};
     use crate::errors::CommError as Error;
-    use crate::manager::{Bssid, EventListener, PingError, Ssid, WifiConnError, WifiConnState};
+    use crate::manager::{
+        AuthType, Bssid, EventListener, PingError, Ssid, WifiConnError, WifiConnState,
+    };
     use crate::stack::sock_holder::SocketStore;
     use crate::{ConnectionInfo, Credentials, S8Password, S8Username, WifiChannel, WpaKey};
     #[cfg(feature = "wep")]

--- a/winc-rs/src/client/wifi_module.rs
+++ b/winc-rs/src/client/wifi_module.rs
@@ -1,5 +1,3 @@
-use crate::errors::CommError as Error;
-
 use embedded_nal::nb;
 
 use crate::manager::{
@@ -7,7 +5,7 @@ use crate::manager::{
     MacAddress, ProvisioningInfo, ScanResult, SocketOptions, Ssid, WifiChannel,
 };
 
-use crate::net_ops::module::{StationMode, SyncOp};
+use crate::net_ops::module::{ProvisioningMode, StationMode, SyncOp};
 
 use crate::stack::socket_callbacks::WifiModuleState;
 
@@ -17,11 +15,6 @@ use crate::{error, info};
 
 // 5 seconds max, assuming no additional delays
 const AP_DISCONNECT_TIMEOUT_MILLISECONDS: u32 = 5_000;
-// Timeout for Provisioning
-#[cfg(not(test))]
-const PROVISIONING_TIMEOUT: u32 = 60 * 1000;
-#[cfg(test)]
-const PROVISIONING_TIMEOUT: u32 = 1000;
 
 impl<X: Xfer> WincClient<'_, X> {
     /// Call this periodically to receive network events
@@ -324,7 +317,8 @@ impl<X: Xfer> WincClient<'_, X> {
         }
     }
 
-    /// Starts the provisioning mode. This command is only applicable when the chip is in station mode.
+    /// Starts the provisioning mode. This command is only applicable when the chip is
+    /// in station mode or unconnected.
     ///
     /// # Arguments
     ///
@@ -337,55 +331,15 @@ impl<X: Xfer> WincClient<'_, X> {
     ///
     /// * `ProvisioningInfo` - Wifi Credentials received from provisioning.
     /// * `StackError` - If an error occurs while starting provisioning mode or receiving provisioning information.
-    pub fn provisioning_mode(
+    pub fn start_provisioning_mode(
         &mut self,
         ap: &AccessPoint,
         hostname: &HostName,
         http_redirect: bool,
         timeout: u32,
     ) -> nb::Result<ProvisioningInfo, StackError> {
-        match &mut self.callbacks.state {
-            WifiModuleState::Unconnected | WifiModuleState::ConnectedToAp => {
-                let auth = <Credentials as Into<AuthType>>::into(ap.key);
-
-                if auth == AuthType::S802_1X {
-                    error!("Enterprise Security in provisioning mode is not supported");
-                    return Err(nb::Error::Other(StackError::InvalidParameters));
-                }
-
-                self.manager
-                    .send_start_provisioning(ap, hostname, http_redirect)?;
-
-                self.callbacks.state = WifiModuleState::Provisioning;
-                self.callbacks.provisioning_info = None;
-            }
-            WifiModuleState::Provisioning => match &mut self.callbacks.provisioning_info {
-                None => {
-                    self.operation_countdown = timeout * PROVISIONING_TIMEOUT;
-                    self.callbacks.provisioning_info = Some(None);
-                }
-                Some(result) => {
-                    if let Some(info) = result.take() {
-                        if info.status {
-                            return Ok(info);
-                        }
-                        return Err(nb::Error::Other(StackError::WincWifiFail(Error::Failed)));
-                    } else {
-                        self.delay_us(self.poll_loop_delay_us);
-                        self.operation_countdown -= 1;
-                        if self.operation_countdown == 0 {
-                            return Err(nb::Error::Other(StackError::GeneralTimeout));
-                        }
-                    }
-                }
-            },
-            _ => {
-                return Err(nb::Error::Other(StackError::InvalidState));
-            }
-        }
-
-        self.dispatch_events_may_wait()?;
-        Err(nb::Error::WouldBlock)
+        let mut op = ProvisioningMode::new(ap, hostname, http_redirect, timeout);
+        self.poll_op(&mut op)
     }
 
     /// Stops provisioning mode. This command is only applicable when the chip is in provisioning mode.
@@ -723,7 +677,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::Unconnected;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1));
 
         assert!(result.is_ok());
         if let Ok(info) = result {
@@ -759,7 +713,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::Unconnected;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1));
 
         assert!(result.is_ok());
         if let Ok(info) = result {
@@ -800,7 +754,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::Unconnected;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1));
 
         assert!(result.is_ok());
         if let Ok(info) = result {
@@ -839,7 +793,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::Unconnected;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1));
 
         assert!(result.is_err());
         if let Err(error) = result {
@@ -863,7 +817,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::ConnectingToAp;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1));
 
         assert!(result.is_err());
         if let Err(err) = result {
@@ -887,7 +841,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::Unconnected;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1500)); // Time is in milliseconds
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1500));
 
         assert!(result.is_err());
         if let Err(err) = result {
@@ -921,7 +875,7 @@ mod tests {
         // set the module state to unconnected.
         client.callbacks.state = WifiModuleState::Unconnected;
 
-        let result = nb::block!(client.provisioning_mode(&ap, &hostname, false, 1));
+        let result = nb::block!(client.start_provisioning_mode(&ap, &hostname, false, 1));
 
         assert!(result.is_err());
         if let Err(error) = result {

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -345,7 +345,7 @@ impl<'a> ProvisioningMode<'a> {
     /// * `http_redirect` - Whether HTTP redirection is enabled.
     /// * `timeout` - The timeout duration for provisioning, in minutes.
     pub fn new(
-        ap: &'a AccessPoint,
+        ap: &'a AccessPoint<'a>,
         hostname: &'a HostName,
         http_redirect: bool,
         timeout: u32,

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -1,8 +1,8 @@
 use crate::error;
 use crate::errors::CommError as Error;
 use crate::manager::{
-    AccessPoint, AuthType, BootState, Credentials, FirmwareInfo, MacAddress, Manager,
-    SocketOptions, Ssid, TcpSockOpts, UdpSockOpts, WifiChannel, ProvisioningInfo, HostName
+    AccessPoint, AuthType, BootState, Credentials, FirmwareInfo, HostName, MacAddress, Manager,
+    ProvisioningInfo, SocketOptions, Ssid, TcpSockOpts, UdpSockOpts, WifiChannel,
 };
 use crate::net_ops::op::OpImpl;
 use crate::stack::{
@@ -579,6 +579,14 @@ impl<'a, X: Xfer> OpImpl<X> for ProvisioningMode<'a> {
     type Error = StackError;
 
     /// Polls the state machine and attempts to initiate provisioning mode.
+    ///
+    /// # Arguments
+    ///
+    /// * `manager` - The stack manager handling low-level operations.
+    /// * `callbacks` - Socket callback handlers.
+    ///
+    /// # Returns
+    ///
     /// * `Ok(Some(output))` - Operation completed successfully.
     /// * `Ok(None)` - Operation is still in progress.
     /// * `Err(Self::Error)` - An error occurred while polling.

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -1,6 +1,8 @@
+use crate::error;
+use crate::errors::CommError as Error;
 use crate::manager::{
     AccessPoint, AuthType, BootState, Credentials, FirmwareInfo, MacAddress, Manager,
-    SocketOptions, Ssid, TcpSockOpts, UdpSockOpts, WifiChannel,
+    SocketOptions, Ssid, TcpSockOpts, UdpSockOpts, WifiChannel, ProvisioningInfo, HostName
 };
 use crate::net_ops::op::OpImpl;
 use crate::stack::{
@@ -18,6 +20,11 @@ use crate::manager::BootMode;
 
 // 1 minute max, if no other delays are added
 const AP_CONNECT_TIMEOUT_MILLISECONDS: u32 = 60_000;
+// Timeout for Provisioning
+#[cfg(not(test))]
+const PROVISIONING_TIMEOUT: u32 = 60 * 1000;
+#[cfg(test)]
+const PROVISIONING_TIMEOUT: u32 = 1000;
 
 /// Synchronous operations type.
 enum SyncOpType<'a> {
@@ -58,6 +65,14 @@ pub(crate) struct StationMode<'a> {
     channel: WifiChannel,
     save_credentials: bool,
     use_defaults: bool,
+}
+
+/// Structure to hold configuration for Provisioning Mode.
+pub(crate) struct ProvisioningMode<'a> {
+    ap: &'a AccessPoint<'a>,
+    hostname: &'a HostName,
+    http_redirect: bool,
+    timeout: u32,
 }
 
 /// Constructors and helpers for synchronous operations.
@@ -319,6 +334,31 @@ impl<'a> StationMode<'a> {
     }
 }
 
+/// Creates configuration instances for Wi-Fi provisioning mode.
+impl<'a> ProvisioningMode<'a> {
+    /// Creates a new `ProvisioningMode` instance with the given configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `ap` - An `AccessPoint` struct containing the SSID, password, and other network details.
+    /// * `hostname` - Device domain name. Must not include `.local`.
+    /// * `http_redirect` - Whether HTTP redirection is enabled.
+    /// * `timeout` - The timeout duration for provisioning, in minutes.
+    pub fn new(
+        ap: &'a AccessPoint,
+        hostname: &'a HostName,
+        http_redirect: bool,
+        timeout: u32,
+    ) -> Self {
+        Self {
+            ap,
+            hostname,
+            http_redirect,
+            timeout,
+        }
+    }
+}
+
 /// Handles Wi-Fi connection operations in station mode.
 impl<X: Xfer> OpImpl<X> for StationMode<'_> {
     type Output = ();
@@ -344,7 +384,7 @@ impl<X: Xfer> OpImpl<X> for StationMode<'_> {
         let state = callbacks.state.clone();
 
         match state {
-            WifiModuleState::Unconnected => {
+            WifiModuleState::Unconnected | WifiModuleState::Provisioning => {
                 callbacks.state = WifiModuleState::ConnectingToAp;
                 manager.set_operation_timeout(AP_CONNECT_TIMEOUT_MILLISECONDS);
                 if self.use_defaults {
@@ -530,6 +570,64 @@ impl<'a, X: Xfer> OpImpl<X> for SyncOp<'a> {
         }
 
         Ok(Some(()))
+    }
+}
+
+/// `OpImpl` trait implementation for `ProvisioningMode`.
+impl<'a, X: Xfer> OpImpl<X> for ProvisioningMode<'a> {
+    type Output = ProvisioningInfo;
+    type Error = StackError;
+
+    /// Polls the state machine and attempts to initiate provisioning mode.
+    /// * `Ok(Some(output))` - Operation completed successfully.
+    /// * `Ok(None)` - Operation is still in progress.
+    /// * `Err(Self::Error)` - An error occurred while polling.
+    fn poll_impl(
+        &mut self,
+        manager: &mut crate::manager::Manager<X>,
+        callbacks: &mut crate::stack::socket_callbacks::SocketCallbacks,
+    ) -> Result<Option<Self::Output>, Self::Error> {
+        match &mut callbacks.state {
+            WifiModuleState::Unconnected | WifiModuleState::ConnectedToAp => {
+                let auth = <Credentials as Into<AuthType>>::into(self.ap.key);
+
+                if auth == AuthType::S802_1X {
+                    error!("Enterprise Security in provisioning mode is not supported");
+                    return Err(StackError::InvalidParameters);
+                }
+
+                manager.send_start_provisioning(self.ap, self.hostname, self.http_redirect)?;
+
+                callbacks.state = WifiModuleState::Provisioning;
+                callbacks.provisioning_info = None;
+            }
+            WifiModuleState::Provisioning => match &mut callbacks.provisioning_info {
+                None => {
+                    manager.set_operation_timeout(self.timeout * PROVISIONING_TIMEOUT);
+                    callbacks.provisioning_info = Some(None);
+                }
+                Some(result) => {
+                    if let Some(info) = result.take() {
+                        if info.status {
+                            return Ok(Some(info));
+                        }
+                        return Err(StackError::WincWifiFail(Error::Failed));
+                    } else {
+                        let mut timeout = manager.get_operation_timeout();
+                        if timeout == 0 {
+                            return Err(StackError::GeneralTimeout);
+                        }
+                        timeout -= 1;
+                        manager.set_operation_timeout(timeout);
+                    }
+                }
+            },
+            _ => {
+                return Err(StackError::InvalidState);
+            }
+        }
+
+        Ok(None)
     }
 }
 

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -612,7 +612,7 @@ impl<'a, X: Xfer> OpImpl<X> for ProvisioningMode<'a> {
                         if info.status {
                             return Ok(Some(info));
                         }
-                        callbacks.provisioning_info = Some(None);
+                        callbacks.provisioning_info = None;
                         return Err(StackError::WincWifiFail(Error::Failed));
                     } else {
                         let mut timeout = manager.get_operation_timeout();

--- a/winc-rs/src/net_ops/module.rs
+++ b/winc-rs/src/net_ops/module.rs
@@ -603,7 +603,8 @@ impl<'a, X: Xfer> OpImpl<X> for ProvisioningMode<'a> {
             }
             WifiModuleState::Provisioning => match &mut callbacks.provisioning_info {
                 None => {
-                    manager.set_operation_timeout(self.timeout * PROVISIONING_TIMEOUT);
+                    manager
+                        .set_operation_timeout(self.timeout.saturating_mul(PROVISIONING_TIMEOUT));
                     callbacks.provisioning_info = Some(None);
                 }
                 Some(result) => {
@@ -611,6 +612,7 @@ impl<'a, X: Xfer> OpImpl<X> for ProvisioningMode<'a> {
                         if info.status {
                             return Ok(Some(info));
                         }
+                        callbacks.provisioning_info = Some(None);
                         return Err(StackError::WincWifiFail(Error::Failed));
                     } else {
                         let mut timeout = manager.get_operation_timeout();


### PR DESCRIPTION
This PR adds support for provisioning mode in the async client and unifies the feature codebase for both the sync and async clients. It also includes unit tests and an async example for feature demonstration.

## Summary by Sourcery

Add unified provisioning mode support for both sync and async Wi-Fi clients and centralize the provisioning operation logic in the shared net_ops layer.

New Features:
- Expose an async `start_provisioning_mode` API on `AsyncClient` to start Wi-Fi provisioning and return received credentials.
- Provide an async provisioning example for the Feather async target demonstrating end-to-end usage.

Enhancements:
- Refactor synchronous client provisioning into a shared `ProvisioningMode` operation in `net_ops`, and rename the sync API to `start_provisioning_mode` for consistency with the async client.
- Allow station connection attempts to start from both unconnected and provisioning states.
- Adjust provisioning timeout handling to be driven by the shared operation implementation and common timeout constants.

Documentation:
- Update the synchronous provisioning example comments and usage to reflect the new `start_provisioning_mode` API and clarify timeout messaging.

Tests:
- Add async provisioning mode tests covering open, WPA, and WEP networks, invalid enterprise configuration, invalid state, timeout, and provisioning failure paths.
- Update existing sync provisioning tests to use the renamed `start_provisioning_mode` API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Wi‑Fi provisioning flow with AP/hostname configuration, redirect and timeout support
  * Added async provisioning API and example demonstrating setup, connect, and heartbeat behavior

* **Refactor**
  * Streamlined provisioning API surface and moved provisioning logic into a dedicated operation for clearer behavior

* **Bug Fixes**
  * Improved timeout messaging and corrected nearby comments/typos

* **Documentation**
  * New examples and updated docs showing provisioning usage and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->