### PR TITLE
Support for Async Ethernet Mode

### DIFF
--- a/feather_async/Cargo.toml
+++ b/feather_async/Cargo.toml
@@ -25,9 +25,8 @@ embassy-time-driver = { version ="0.2" }
 embassy-time = { version = "0.5.1" }
 embedded-nal-async = { version = "0.9" }
 demos_async = { path = "../demos_async", default-features = false, features = ["defmt"] }
-embassy-futures = { version = "0.1.2", default-features = false, optional = true }
 static_cell = { version = "2.1.1", default-features = false, optional = true }
-portable-atomic = { version = "1.13.1", default-features = false, features = ["critical-section"] }
+portable-atomic = { version = "1.13.1", default-features = false, features = ["critical-section"], optional = true }
 
 # Embassy Net
 [dependencies.embassy-net]
@@ -41,7 +40,7 @@ name = "bypass_mode"
 required-features = ["external-tcp-stack"]
 
 [features]
-external-tcp-stack = ["wincwifi/embassy-net", "dep:embassy-net", "dep:embassy-futures", "dep:static_cell"]
+external-tcp-stack = ["wincwifi/embassy-net", "dep:embassy-net", "dep:static_cell", "dep:portable-atomic"]
 
 # cargo build/run
 [profile.dev]

--- a/feather_async/Cargo.toml
+++ b/feather_async/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 harness = false
 
 [dependencies]
-cortex-m = { version = "0.7.3", features = ["critical-section-single-core"] }
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 defmt = "0.3"
 defmt-rtt = "0.4"
@@ -22,9 +22,26 @@ wincwifi = { path = "../winc-rs", default-features = false, features=["defmt", "
 embassy-executor = { version = "0.7" , features= ["arch-cortex-m", "executor-thread", "defmt", "task-arena-size-6144"] }
 systick-timer = { version = "0.2.2",  features=["cortex-m","embassy-time-driver"] }
 embassy-time-driver = { version ="0.2" }
-embassy-time = { version = "0.4" }
+embassy-time = { version = "0.5.1" }
 embedded-nal-async = { version = "0.9" }
 demos_async = { path = "../demos_async", default-features = false, features = ["defmt"] }
+embassy-futures = { version = "0.1.2", default-features = false, optional = true }
+static_cell = { version = "2.1.1", default-features = false, optional = true }
+portable-atomic = { version = "1.13.1", default-features = false, features = ["critical-section"] }
+
+# Embassy Net
+[dependencies.embassy-net]
+version = "0.9.1"
+default-features = false
+optional = true
+features = ["medium-ethernet", "proto-ipv4", "raw", "udp", "icmp", "dns", "dhcpv4-hostname", "dhcpv4", "auto-icmp-echo-reply"]
+
+[[example]]
+name = "bypass_mode"
+required-features = ["external-tcp-stack"]
+
+[features]
+external-tcp-stack = ["wincwifi/embassy-net", "dep:embassy-net", "dep:embassy-futures", "dep:static_cell"]
 
 # cargo build/run
 [profile.dev]

--- a/feather_async/Cargo.toml
+++ b/feather_async/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 harness = false
 
 [dependencies]
-cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
+cortex-m = { version = "0.7.3", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/feather_async/examples/bypass_mode.rs
+++ b/feather_async/examples/bypass_mode.rs
@@ -60,7 +60,10 @@ async fn wait_for_dhcp(stack: &Stack<'static>) -> Result<(), AppError> {
     loop {
         if let Some(config) = stack.config_v4() {
             let ip: [u8; MAX_IP_BYTES] = config.address.address().octets();
-            let gateway: [u8; MAX_IP_BYTES] = config.gateway.unwrap().octets();
+            let gateway: [u8; MAX_IP_BYTES] = config
+                .gateway
+                .ok_or(AppError::WincError(StackError::InvalidResponse))?
+                .octets();
             let mask: [u8; MAX_IP_BYTES] = config.address.netmask().octets();
             defmt::info!("IP address: {}.{}.{}.{}", ip[0], ip[1], ip[2], ip[3]);
             defmt::info!(
@@ -98,8 +101,11 @@ async fn wait_for_dhcp(stack: &Stack<'static>) -> Result<(), AppError> {
 #[embassy_executor::task]
 async fn ping_task(stack: Stack<'static>, destination_ip: Ipv4Addr, count: u16) -> ! {
     // Wait for DHCP
-    if let Err(_) = wait_for_dhcp(&stack).await {
-        loop {}
+    if let Err(err) = wait_for_dhcp(&stack).await {
+        defmt::error!("DHCP error: {:?}", err);
+        loop {
+            Timer::after(Duration::from_secs(1)).await
+        }
     }
 
     // Then we can use it!
@@ -142,7 +148,9 @@ async fn ping_task(stack: Stack<'static>, destination_ip: Ipv4Addr, count: u16) 
         }
     }
 
-    loop {}
+    loop {
+        embassy_time::Timer::after_secs(3600).await
+    }
 }
 
 /// Main Program
@@ -155,7 +163,7 @@ async fn program(spwaner: Spawner) -> Result<(), AppError> {
     let test_ip: Ipv4Addr =
         Ipv4Addr::from_str(test_ip).map_err(|_| StackError::InvalidParameters)?;
     let test_count = option_env!("TEST_COUNT").unwrap_or(DEFAULT_TEST_COUNT);
-    let test_count = u16::from_str(test_count).unwrap();
+    let test_count = u16::from_str(test_count).map_err(|_| StackError::InvalidParameters)?;
 
     let ssid = Ssid::from(option_env!("TEST_SSID").unwrap_or(DEFAULT_TEST_SSID))
         .map_err(|_| StackError::InvalidParameters)?;

--- a/feather_async/examples/bypass_mode.rs
+++ b/feather_async/examples/bypass_mode.rs
@@ -5,51 +5,106 @@
 
 use core::net::Ipv4Addr;
 use core::str::FromStr;
-
 use embassy_executor::Spawner;
-use embassy_futures::yield_now;
-use embassy_net::icmp::ping::{PingManager, PingParams};
-use embassy_net::icmp::PacketMetadata;
+use embassy_net::icmp::{
+    ping::{PingManager, PingParams},
+    PacketMetadata,
+};
 use embassy_net::{Config, Stack, StackResources};
-use embassy_time::Duration;
-use feather_async::init::init;
-use feather_async::shared::{AppError, SpiStream};
+use embassy_time::{Duration, Instant, Timer};
+use feather_async::{
+    init::init,
+    shared::{AppError, SpiStream},
+};
 use static_cell::StaticCell;
 use wincwifi::{AsyncClient, Credentials, Ssid, StackError, WifiChannel};
 
+// Default values for the example
 const DEFAULT_TEST_SSID: &str = "network";
 const DEFAULT_TEST_PASSWORD: &str = "password";
 const DEFAULT_TEST_IP: &str = "8.8.8.8";
 const DEFAULT_TEST_COUNT: &str = "4";
+// Maximum number of bytes in IP address
+const MAX_IP_BYTES: usize = 4;
+// Max storage size for ICMP storage.
+const MAX_ICMP_STORAGE_SIZE: usize = 256;
+// Timeout before sending a new Ping packet
+const PING_PACKET_TIMEOUT: u64 = 500;
+// Custom payload for the Ping packet
+const PING_PACKET_PAYLOAD: &[u8] = b"Hello, Ping!";
+// Maximum bytes in the random seed
+const MAX_RANDOM_SEED_BYTES: usize = 8;
+// Resources for the network stack
+const RESOURCE_CAPACITY: usize = 3;
+// Timeout for DHCP
+const DHCP_TIMEOUT: Duration = Duration::from_secs(30);
+// Poll interval for DHCP
+const DHCP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+/// Static cell for storing network stack resources.
+static RESOURCES: StaticCell<StackResources<RESOURCE_CAPACITY>> = StaticCell::new();
 
-async fn wait_for_dhcp(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+/// Waits for DHCP to complete and returns the static configuration.
+///
+/// # Arguments
+///
+/// * `stack` - The network stack instance.
+///
+/// # Returns
+///
+/// * `embassy_net::StaticConfigV4` - The static configuration for the network.
+async fn wait_for_dhcp(stack: &Stack<'static>) -> Result<(), AppError> {
+    let timeout = Instant::now() + DHCP_TIMEOUT;
     defmt::info!("Waiting for DHCP...");
+
     loop {
         if let Some(config) = stack.config_v4() {
-            return config.clone();
+            let ip: [u8; MAX_IP_BYTES] = config.address.address().octets();
+            let gateway: [u8; MAX_IP_BYTES] = config.gateway.unwrap().octets();
+            let mask: [u8; MAX_IP_BYTES] = config.address.netmask().octets();
+            defmt::info!("IP address: {}.{}.{}.{}", ip[0], ip[1], ip[2], ip[3]);
+            defmt::info!(
+                "Gateway address: {}.{}.{}.{}",
+                gateway[0],
+                gateway[1],
+                gateway[2],
+                gateway[3]
+            );
+            defmt::info!(
+                "DNS server: {}.{}.{}.{}",
+                mask[0],
+                mask[1],
+                mask[2],
+                mask[3]
+            );
+            return Ok(());
         }
-        yield_now().await;
+        if Instant::now() > timeout {
+            defmt::error!("DHCP timeout after {}s", DHCP_TIMEOUT.as_secs());
+            return Err(AppError::WincError(StackError::GeneralTimeout));
+        }
+
+        Timer::after(DHCP_POLL_INTERVAL).await;
     }
 }
 
+/// Pings the specified IP address using the ICMP protocol.
+///
+/// # Arguments
+///
+/// * `stack` - The network stack instance.
+/// * `destination_ip` - The IP address to ping.
+/// * `count` - The number of pings to send.
 #[embassy_executor::task]
 async fn ping_task(stack: Stack<'static>, destination_ip: Ipv4Addr, count: u16) -> ! {
     // Wait for DHCP
-    let cfg = wait_for_dhcp(stack).await;
-    let local_addr = cfg.address.address().octets();
-    defmt::info!(
-        "IP address: {}.{}.{}.{}",
-        local_addr[0],
-        local_addr[1],
-        local_addr[2],
-        local_addr[3]
-    );
+    if let Err(_) = wait_for_dhcp(&stack).await {
+        loop {}
+    }
 
     // Then we can use it!
-    let mut rx_buffer = [0; 256];
-    let mut tx_buffer = [0; 256];
+    let mut rx_buffer = [0; MAX_ICMP_STORAGE_SIZE];
+    let mut tx_buffer = [0; MAX_ICMP_STORAGE_SIZE];
     let mut rx_meta = [PacketMetadata::EMPTY];
     let mut tx_meta = [PacketMetadata::EMPTY];
 
@@ -65,16 +120,16 @@ async fn ping_task(stack: Stack<'static>, destination_ip: Ipv4Addr, count: u16) 
     // Create the PingParams with the destination address
     let mut ping_params = PingParams::new(destination_ip);
     // (optional) Set custom properties of the ping
-    ping_params.set_payload(b"Hello, Ping!"); // custom payload
-    ping_params.set_count(count); // ping 1 times per ping call
-    ping_params.set_timeout(Duration::from_millis(500)); // wait .5 seconds instead of 4
+    ping_params.set_payload(PING_PACKET_PAYLOAD); // custom payload
+    ping_params.set_count(count);
+    ping_params.set_timeout(Duration::from_millis(PING_PACKET_TIMEOUT));
 
     // Execute the ping with the given parameters and wait for the reply
     match ping_manager.ping(&ping_params).await {
         Ok(time) => {
             let ip_octets = destination_ip.octets();
             defmt::info!(
-                "Ping {}.{}.{}.{} succeeded, latency: {} ms",
+                "Ping from {}.{}.{}.{} succeeded, latency: {} ms",
                 ip_octets[0],
                 ip_octets[1],
                 ip_octets[2],
@@ -83,16 +138,14 @@ async fn ping_task(stack: Stack<'static>, destination_ip: Ipv4Addr, count: u16) 
             );
         }
         Err(_) => {
-            // Todo add error handling
             defmt::error!("Ping failed");
         }
     }
 
-    defmt::info!("Ping task complete");
-
     loop {}
 }
 
+/// Main Program
 async fn program(spwaner: Spawner) -> Result<(), AppError> {
     let ini = init().await?;
 
@@ -128,12 +181,12 @@ async fn program(spwaner: Spawner) -> Result<(), AppError> {
     defmt::info!("Connected to Access point...");
 
     // Generate seed
-    let mut random_bytes = [0u8; 8];
+    let mut random_bytes = [0u8; MAX_RANDOM_SEED_BYTES];
     module.get_random_bytes(&mut random_bytes).await?;
     let seed = u64::from_le_bytes(random_bytes);
 
     // Init network
-    let resources = RESOURCES.init(StackResources::<3>::new());
+    let resources = RESOURCES.init(StackResources::<RESOURCE_CAPACITY>::new());
     let (stack, mut runner) =
         embassy_net::new(module, Config::dhcpv4(Default::default()), resources, seed);
 
@@ -145,6 +198,7 @@ async fn program(spwaner: Spawner) -> Result<(), AppError> {
     runner.run().await;
 }
 
+/// The main program entry point.
 #[embassy_executor::main]
 async fn main(s: embassy_executor::Spawner) -> ! {
     if let Err(err) = program(s).await {

--- a/feather_async/examples/bypass_mode.rs
+++ b/feather_async/examples/bypass_mode.rs
@@ -1,0 +1,157 @@
+//! Ethernet bypass mode example
+
+#![no_std]
+#![no_main]
+
+use core::net::Ipv4Addr;
+use core::str::FromStr;
+
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::icmp::ping::{PingManager, PingParams};
+use embassy_net::icmp::PacketMetadata;
+use embassy_net::{Config, Stack, StackResources};
+use embassy_time::Duration;
+use feather_async::init::init;
+use feather_async::shared::{AppError, SpiStream};
+use static_cell::StaticCell;
+use wincwifi::{AsyncClient, Credentials, Ssid, StackError, WifiChannel};
+
+const DEFAULT_TEST_SSID: &str = "network";
+const DEFAULT_TEST_PASSWORD: &str = "password";
+const DEFAULT_TEST_IP: &str = "8.8.8.8";
+const DEFAULT_TEST_COUNT: &str = "4";
+
+static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+
+async fn wait_for_dhcp(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    defmt::info!("Waiting for DHCP...");
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}
+
+#[embassy_executor::task]
+async fn ping_task(stack: Stack<'static>, destination_ip: Ipv4Addr, count: u16) -> ! {
+    // Wait for DHCP
+    let cfg = wait_for_dhcp(stack).await;
+    let local_addr = cfg.address.address().octets();
+    defmt::info!(
+        "IP address: {}.{}.{}.{}",
+        local_addr[0],
+        local_addr[1],
+        local_addr[2],
+        local_addr[3]
+    );
+
+    // Then we can use it!
+    let mut rx_buffer = [0; 256];
+    let mut tx_buffer = [0; 256];
+    let mut rx_meta = [PacketMetadata::EMPTY];
+    let mut tx_meta = [PacketMetadata::EMPTY];
+
+    // Create the ping manager instance
+    let mut ping_manager = PingManager::new(
+        stack,
+        &mut rx_meta,
+        &mut rx_buffer,
+        &mut tx_meta,
+        &mut tx_buffer,
+    );
+
+    // Create the PingParams with the destination address
+    let mut ping_params = PingParams::new(destination_ip);
+    // (optional) Set custom properties of the ping
+    ping_params.set_payload(b"Hello, Ping!"); // custom payload
+    ping_params.set_count(count); // ping 1 times per ping call
+    ping_params.set_timeout(Duration::from_millis(500)); // wait .5 seconds instead of 4
+
+    // Execute the ping with the given parameters and wait for the reply
+    match ping_manager.ping(&ping_params).await {
+        Ok(time) => {
+            let ip_octets = destination_ip.octets();
+            defmt::info!(
+                "Ping {}.{}.{}.{} succeeded, latency: {} ms",
+                ip_octets[0],
+                ip_octets[1],
+                ip_octets[2],
+                ip_octets[3],
+                time.as_millis()
+            );
+        }
+        Err(_) => {
+            // Todo add error handling
+            defmt::error!("Ping failed");
+        }
+    }
+
+    defmt::info!("Ping task complete");
+
+    loop {}
+}
+
+async fn program(spwaner: Spawner) -> Result<(), AppError> {
+    let ini = init().await?;
+
+    defmt::info!("Hello, Winc Async Embassy Net Ping Example");
+
+    let test_ip = option_env!("TEST_IP").unwrap_or(DEFAULT_TEST_IP);
+    let test_ip: Ipv4Addr =
+        Ipv4Addr::from_str(test_ip).map_err(|_| StackError::InvalidParameters)?;
+    let test_count = option_env!("TEST_COUNT").unwrap_or(DEFAULT_TEST_COUNT);
+    let test_count = u16::from_str(test_count).unwrap();
+
+    let ssid = Ssid::from(option_env!("TEST_SSID").unwrap_or(DEFAULT_TEST_SSID))
+        .map_err(|_| StackError::InvalidParameters)?;
+    let password = option_env!("TEST_PASSWORD").unwrap_or(DEFAULT_TEST_PASSWORD);
+    let credentials = Credentials::from_wpa(password)?;
+
+    defmt::info!(
+        "Connecting to network: {} with password: {}",
+        ssid.as_str(),
+        password
+    );
+
+    let mut module = AsyncClient::new(SpiStream::new(ini.cs, ini.spi));
+    defmt::info!("Initializing module in ethernet mode");
+    module.start_in_ethernet_mode().await?;
+
+    defmt::info!("Module initialized in ethernet mode");
+
+    defmt::info!("Connecting to Access point...");
+    module
+        .connect_to_ap(&ssid, &credentials, WifiChannel::ChannelAll, false)
+        .await?;
+    defmt::info!("Connected to Access point...");
+
+    // Generate seed
+    let mut random_bytes = [0u8; 8];
+    module.get_random_bytes(&mut random_bytes).await?;
+    let seed = u64::from_le_bytes(random_bytes);
+
+    // Init network
+    let resources = RESOURCES.init(StackResources::<3>::new());
+    let (stack, mut runner) =
+        embassy_net::new(module, Config::dhcpv4(Default::default()), resources, seed);
+
+    // Start the ping task
+    spwaner
+        .spawn(ping_task(stack, test_ip, test_count))
+        .expect("Failed to spawn ping task");
+
+    runner.run().await;
+}
+
+#[embassy_executor::main]
+async fn main(s: embassy_executor::Spawner) -> ! {
+    if let Err(err) = program(s).await {
+        defmt::error!("Error: {}", err);
+        panic!("Error in main program");
+    } else {
+        defmt::info!("Good exit")
+    };
+    loop {}
+}

--- a/winc-rs/Cargo.toml
+++ b/winc-rs/Cargo.toml
@@ -53,6 +53,8 @@ rand_core = { version = "0.9", default-features = false, optional = true }
 
 # smoltcp
 smoltcp = { version = "0.12.0", default-features = false, features = [ "proto-ipv4", "medium-ethernet", "socket-raw" ], optional = true }
+# embassy-net
+embassy-net-driver =  { version = "0.2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 macro_rules_attribute = "0.2"
@@ -76,6 +78,7 @@ ssl = [] # Enable SSL.
 experimental-ecc = ["ssl"] # Enables the ECDSA/ECDH functions. Depends on "ssl".
 ethernet = [] # Support for ethernet mode.
 smoltcp = ["ethernet", "dep:smoltcp"]
+embassy-net = ["ethernet", "dep:embassy-net-driver"]
 
 # Todo: add feature flags to save binary space
 # - TCP

--- a/winc-rs/src/async_client/ethernet.rs
+++ b/winc-rs/src/async_client/ethernet.rs
@@ -14,7 +14,7 @@ impl<X: Xfer> AsyncClient<'_, X> {
     /// # Arguments
     ///
     /// * `buffer` - A mutable slice used to store the received Ethernet packet.
-    /// * `timeout` - An optional duration to wait for a packet.
+    /// * `timeout` - An optional duration to wait for an Ethernet packet.
     ///   If `None`, the default timeout value `ETHERNET_RX_TIMEOUT_MSEC` is used.
     ///
     /// # Returns
@@ -23,11 +23,11 @@ impl<X: Xfer> AsyncClient<'_, X> {
     /// * `Err(StackError)` - If an error occurs while reading the ethernet packet.
     pub async fn read_ethernet_packet(
         &mut self,
-        buffer: Option<&mut [u8]>,
+        buffer: &mut [u8],
         timeout: Option<Duration>,
     ) -> Result<usize, StackError> {
         let timeout_ms: Option<u32> = timeout.map(|d| d.as_millis().min(u32::MAX as u128) as u32);
-        let mut op = RxEthernetPacketInfo::new(buffer, timeout_ms);
+        let mut op = RxEthernetPacketInfo::new(Some(buffer), timeout_ms);
         self.poll_op(&mut op).await
     }
 
@@ -53,7 +53,7 @@ impl<X: Xfer> AsyncClient<'_, X> {
 
 #[cfg(feature = "embassy-net")]
 mod embassy_net {
-    use super::{AsyncClient, Xfer};
+    use super::{AsyncClient, StackError, Xfer};
     use crate::error;
     use crate::manager::{Manager, MAX_OCTETS_IN_MAC_ADDRESS, SOCKET_BUFFER_MAX_LENGTH};
     use crate::ops::net_ops::ethernet_receive::RxEthernetPacketInfo;
@@ -93,7 +93,7 @@ mod embassy_net {
         /// Construct a token pair consisting of one receive token and one transmit token.
         fn receive(
             &mut self,
-            _cx: &mut Context<'_>,
+            cx: &mut Context<'_>,
         ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
             // poll for new events
             let _ = self.heartbeat();
@@ -102,9 +102,26 @@ mod embassy_net {
             let mut rx_op = RxEthernetPacketInfo::new(None, Some(ETH_RECV_TIMEOUT_MSEC));
             let result = self.poll_once(&mut rx_op);
 
-            let Ok(read_length) = result else {
-                return None;
+            let read_length = match result {
+                Ok(length) => length,
+                Err(e) => {
+                    if e == StackError::GeneralTimeout {
+                        error!("Ethernet receive timeout");
+                    }
+                    // register the waker if no packet is available
+                    if let Err(e) = self
+                        .manager
+                        .borrow_mut()
+                        .register_waker_if_new(cx.waker().clone())
+                    {
+                        error!("Too many wakers registered: {:?}", e);
+                    }
+                    return None;
+                }
             };
+
+            // Got a packet - remove the waker.
+            self.manager.borrow_mut().unregister_waker(&cx.waker());
 
             let rx_token = WincRxToken {
                 callback: &self.callbacks,
@@ -234,7 +251,7 @@ mod tests {
             let mut client = make_test_client();
             *client.debug_callback.borrow_mut() = Some(&mut my_debug);
             client
-                .read_ethernet_packet(Some(rx_buffer.as_mut_slice()), None)
+                .read_ethernet_packet(rx_buffer.as_mut_slice(), None)
                 .await
         };
 
@@ -248,7 +265,7 @@ mod tests {
         let timeout = Some(Duration::from_millis(1000));
 
         let result = client
-            .read_ethernet_packet(Some(rx_buffer.as_mut_slice()), timeout)
+            .read_ethernet_packet(rx_buffer.as_mut_slice(), timeout)
             .await;
 
         assert_eq!(result, Err(StackError::GeneralTimeout));

--- a/winc-rs/src/async_client/ethernet.rs
+++ b/winc-rs/src/async_client/ethernet.rs
@@ -106,7 +106,7 @@ mod embassy_net {
                 Ok(length) => length,
                 Err(e) => {
                     if e == StackError::GeneralTimeout {
-                        error!("Ethernet receive timeout");
+                        crate::warn!("Ethernet receive timeout");
                     }
                     // register the waker if no packet is available
                     if let Err(e) = self
@@ -114,7 +114,7 @@ mod embassy_net {
                         .borrow_mut()
                         .register_waker_if_new(cx.waker().clone())
                     {
-                        error!("Too many wakers registered: {:?}", e);
+                        crate::warn!("Too many wakers registered: {:?}", e);
                     }
                     return None;
                 }

--- a/winc-rs/src/async_client/ethernet.rs
+++ b/winc-rs/src/async_client/ethernet.rs
@@ -1,0 +1,184 @@
+use super::AsyncClient;
+use crate::ops::{module::SyncOp, net_ops::ethernet_receive::RxEthernetPacketInfo};
+use crate::stack::StackError;
+use crate::transfer::Xfer;
+
+impl<X: Xfer> AsyncClient<'_, X> {
+    /// Tries to read an Ethernet packet from the module within a specified timeout.
+    ///
+    /// # Note
+    ///
+    /// The user application is responsible for parsing the Ethernet packet.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - A mutable slice used to store the received Ethernet packet.
+    /// * `timeout` - An optional duration to wait for a packet.
+    ///   If `None`, the default timeout value `ETHERNET_RX_TIMEOUT_MSEC` is used.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(usize)` - The number of bytes read from the module.
+    /// * `Err(StackError)` - If an error occurs while reading the ethernet packet.
+    pub async fn read_ethernet_packet(
+        &mut self,
+        buffer: Option<&mut [u8]>,
+        timeout: Option<u32>,
+    ) -> Result<usize, StackError> {
+        let mut op = RxEthernetPacketInfo::new(buffer, timeout);
+        self.poll_op(&mut op).await
+    }
+
+    /// Sends an Ethernet packet to the module.
+    ///
+    /// # Note
+    ///
+    /// The user application is responsible for constructing the Ethernet packet.
+    ///
+    /// # Arguments
+    ///
+    /// * `net_pkt` - The raw Ethernet packet data to be transmitted.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If packet is successfully sent to the module.
+    /// * `Err(StackError)` - If an error occurred while sending the ethernet packet.
+    pub fn send_ethernet_packet(&mut self, net_pkt: &[u8]) -> Result<(), StackError> {
+        let mut op = SyncOp::send_ethernet_packet(net_pkt);
+        self.poll_once(&mut op)
+    }
+}
+
+#[cfg(feature = "embassy-net")]
+mod embassy_net {
+    use super::{AsyncClient, Xfer};
+    use crate::error;
+    use crate::manager::{Manager, MAX_OCTETS_IN_MAC_ADDRESS, SOCKET_BUFFER_MAX_LENGTH};
+    use crate::ops::net_ops::ethernet_receive::RxEthernetPacketInfo;
+    use crate::stack::socket_callbacks::SocketCallbacks;
+    use core::cell::RefCell;
+    use core::task::Context;
+    use embassy_net_driver::{Capabilities, HardwareAddress, LinkState};
+
+    // 100 milliseconds timeout to wait for ethernet packet to arrive.
+    const ETH_RECV_TIMEOUT_MSEC: u32 = 100;
+    /// Default Mac address
+    const DEFAULT_MAC_ADDRESS: [u8; MAX_OCTETS_IN_MAC_ADDRESS] = [00, 0x1E, 0xC0, 00, 00, 00];
+
+    /// Container for sending a single network packet.
+    pub struct WincTxToken<'a, X: Xfer> {
+        client: &'a RefCell<Manager<X>>,
+    }
+
+    /// Container for receiving a single network packet.
+    pub struct WincRxToken<'a> {
+        callback: &'a RefCell<SocketCallbacks>,
+        read_length: usize,
+    }
+
+    /// Implementation of an interface for sending and receiving raw network frames.
+    impl<X: Xfer> embassy_net_driver::Driver for AsyncClient<'_, X> {
+        type RxToken<'a>
+            = WincRxToken<'a>
+        where
+            Self: 'a;
+
+        type TxToken<'a>
+            = WincTxToken<'a, X>
+        where
+            Self: 'a;
+
+        /// Construct a token pair consisting of one receive token and one transmit token.
+        fn receive(
+            &mut self,
+            cx: &mut Context<'_>,
+        ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+            // poll for new events
+            let _ = self.heartbeat();
+
+            // poll for a packet
+            let mut rx_op = RxEthernetPacketInfo::new(None, Some(ETH_RECV_TIMEOUT_MSEC));
+            let result = self.poll_once(&mut rx_op);
+
+            let Ok(read_length) = result else {
+                // Waker is registered, poll the winc heatbeat before polling the embassy interface.TODO: make this clearer
+                let _ = self.manager.borrow_mut().register_waker(cx.waker().clone());
+                return None;
+            };
+
+            // unregister the waker
+            self.manager.borrow_mut().unregister_waker(&cx.waker());
+
+            let rx_token = WincRxToken {
+                callback: &self.callbacks,
+                read_length,
+            };
+
+            let tx_token = WincTxToken {
+                client: &self.manager,
+            };
+            Some((rx_token, tx_token))
+        }
+
+        /// Construct a transmit token.
+        fn transmit(&mut self, _cx: &mut Context<'_>) -> Option<Self::TxToken<'_>> {
+            let tx_token = WincTxToken {
+                client: &self.manager,
+            };
+            Some(tx_token)
+        }
+
+        /// Get a description of device capabilities.
+        fn capabilities(&self) -> Capabilities {
+            let mut cap = Capabilities::default();
+            cap.max_transmission_unit = SOCKET_BUFFER_MAX_LENGTH;
+            cap.max_burst_size = Some(1);
+
+            cap
+        }
+
+        fn link_state(&mut self, _cx: &mut core::task::Context) -> LinkState {
+            // TODO:
+            LinkState::Up
+        }
+
+        fn hardware_address(&self) -> HardwareAddress {
+            match self.get_winc_mac_address() {
+                Ok(mac) => HardwareAddress::Ethernet(mac.octets()),
+                Err(_) => HardwareAddress::Ethernet(DEFAULT_MAC_ADDRESS),
+            }
+        }
+    }
+
+    impl<'a> embassy_net_driver::RxToken for WincRxToken<'a> {
+        /// Consumes the token to receive a single network packet.
+        fn consume<R, F>(self, f: F) -> R
+        where
+            F: FnOnce(&mut [u8]) -> R,
+        {
+            let length = self.read_length;
+            f(&mut self.callback.borrow_mut().recv_buffer[..length])
+        }
+    }
+
+    impl<'a, X: Xfer> embassy_net_driver::TxToken for WincTxToken<'a, X> {
+        /// Consumes the token to send a single network packet.
+        fn consume<R, F>(self, len: usize, f: F) -> R
+        where
+            F: FnOnce(&mut [u8]) -> R,
+        {
+            let mut tx_buffer = [0u8; SOCKET_BUFFER_MAX_LENGTH];
+            let result = f(&mut tx_buffer[..len]);
+
+            if let Err(e) = self
+                .client
+                .borrow_mut()
+                .send_ethernet_packet(&tx_buffer[..len])
+            {
+                error!("Failed to send ethernet packet: {:?}", e);
+            }
+
+            result
+        }
+    }
+}

--- a/winc-rs/src/async_client/ethernet.rs
+++ b/winc-rs/src/async_client/ethernet.rs
@@ -2,6 +2,7 @@ use super::AsyncClient;
 use crate::ops::{module::SyncOp, net_ops::ethernet_receive::RxEthernetPacketInfo};
 use crate::stack::StackError;
 use crate::transfer::Xfer;
+use core::time::Duration;
 
 impl<X: Xfer> AsyncClient<'_, X> {
     /// Tries to read an Ethernet packet from the module within a specified timeout.
@@ -23,9 +24,10 @@ impl<X: Xfer> AsyncClient<'_, X> {
     pub async fn read_ethernet_packet(
         &mut self,
         buffer: Option<&mut [u8]>,
-        timeout: Option<u32>,
+        timeout: Option<Duration>,
     ) -> Result<usize, StackError> {
-        let mut op = RxEthernetPacketInfo::new(buffer, timeout);
+        let timeout_ms: Option<u32> = timeout.map(|d| d.as_millis().min(u32::MAX as u128) as u32);
+        let mut op = RxEthernetPacketInfo::new(buffer, timeout_ms);
         self.poll_op(&mut op).await
     }
 
@@ -91,7 +93,7 @@ mod embassy_net {
         /// Construct a token pair consisting of one receive token and one transmit token.
         fn receive(
             &mut self,
-            cx: &mut Context<'_>,
+            _cx: &mut Context<'_>,
         ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
             // poll for new events
             let _ = self.heartbeat();
@@ -101,13 +103,8 @@ mod embassy_net {
             let result = self.poll_once(&mut rx_op);
 
             let Ok(read_length) = result else {
-                // Waker is registered, poll the winc heatbeat before polling the embassy interface.TODO: make this clearer
-                let _ = self.manager.borrow_mut().register_waker(cx.waker().clone());
                 return None;
             };
-
-            // unregister the waker
-            self.manager.borrow_mut().unregister_waker(&cx.waker());
 
             let rx_token = WincRxToken {
                 callback: &self.callbacks,
@@ -137,13 +134,23 @@ mod embassy_net {
             cap
         }
 
+        /// Get the current link state.
         fn link_state(&mut self, _cx: &mut core::task::Context) -> LinkState {
-            // TODO:
-            LinkState::Up
+            if self.callbacks.borrow().connection_state.conn_state
+                == crate::manager::WifiConnState::Connected
+            {
+                LinkState::Up
+            } else {
+                LinkState::Down
+            }
         }
 
+        /// Get the hardware address of the device.
         fn hardware_address(&self) -> HardwareAddress {
-            match self.get_winc_mac_address() {
+            match self.get_winc_mac_address(
+                #[cfg(test)]
+                false,
+            ) {
                 Ok(mac) => HardwareAddress::Ethernet(mac.octets()),
                 Err(_) => HardwareAddress::Ethernet(DEFAULT_MAC_ADDRESS),
             }
@@ -180,5 +187,106 @@ mod embassy_net {
 
             result
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::make_test_client;
+    use super::*;
+    use crate::manager::{EventListener, MAX_TX_ETHERNET_PACKET_SIZE};
+    use crate::stack::socket_callbacks::SocketCallbacks;
+    use crate::CommError;
+    use macro_rules_attribute::apply;
+    use smol_macros::test;
+
+    #[test]
+    fn test_async_send_ethernet_packet_success() {
+        let mut client = make_test_client();
+        let packet = [0xffu8; 10];
+
+        let result = client.send_ethernet_packet(&packet);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_async_send_ethernet_packet_failed() {
+        let mut client = make_test_client();
+        let result = client.send_ethernet_packet(&[]);
+
+        assert_eq!(
+            result,
+            Err(StackError::WincWifiFail(CommError::BufferError))
+        );
+    }
+
+    #[apply(test!)]
+    async fn test_async_read_ethernet_packet_success() {
+        let rx_info = (100 as u16, 111 as u16, 0xAABBCCDD as u32);
+        let mut rx_buffer = [0u8; 200];
+
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_eth(rx_info.0, rx_info.1, rx_info.2);
+        };
+
+        let result = {
+            let mut client = make_test_client();
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            client
+                .read_ethernet_packet(Some(rx_buffer.as_mut_slice()), None)
+                .await
+        };
+
+        assert!(result.is_ok());
+    }
+
+    #[apply(test!)]
+    async fn test_async_read_ethernet_packet_timeout() {
+        let mut client = make_test_client();
+        let mut rx_buffer = [0u8; 200];
+        let timeout = Some(Duration::from_millis(1000));
+
+        let result = client
+            .read_ethernet_packet(Some(rx_buffer.as_mut_slice()), timeout)
+            .await;
+
+        assert_eq!(result, Err(StackError::GeneralTimeout));
+    }
+
+    #[apply(test!)]
+    async fn test_async_read_ethernet_packet_internal_buffer() {
+        let timeout = Some(1000 as u32);
+        let mut my_debug = |callbacks: &mut SocketCallbacks| {
+            callbacks.on_eth(1600 as u16, 111 as u16, 0xAABBCCDD as u32);
+        };
+        let client = make_test_client();
+
+        let result = {
+            client.callbacks.borrow_mut().recv_buffer.fill(0xff);
+            *client.debug_callback.borrow_mut() = Some(&mut my_debug);
+            let mut op = RxEthernetPacketInfo::new(None, timeout);
+            client.poll_op(&mut op).await
+        };
+
+        assert!(result.is_ok());
+        assert!(client
+            .callbacks
+            .borrow_mut()
+            .recv_buffer
+            .iter()
+            .all(|&b| b == 0));
+    }
+
+    #[apply(test!)]
+    async fn test_async_read_ethernet_over_range() {
+        let mut client = make_test_client();
+        let packet = [0u8; MAX_TX_ETHERNET_PACKET_SIZE + 1];
+        let result = client.send_ethernet_packet(&packet);
+
+        assert_eq!(
+            result,
+            Err(StackError::WincWifiFail(CommError::BufferError))
+        );
     }
 }

--- a/winc-rs/src/async_client/mod.rs
+++ b/winc-rs/src/async_client/mod.rs
@@ -14,6 +14,9 @@ mod module;
 mod tcp_stack;
 mod udp_stack;
 
+#[cfg(feature = "ethernet")]
+mod ethernet;
+
 pub struct AsyncClient<'a, X: Xfer> {
     manager: RefCell<Manager<X>>,
     callbacks: RefCell<SocketCallbacks>,

--- a/winc-rs/src/async_client/module.rs
+++ b/winc-rs/src/async_client/module.rs
@@ -137,7 +137,7 @@ impl<X: Xfer> AsyncClient<'_, X> {
     /// * `Ok(MacAddress)` - The current MAC address of the WINC module on success.
     /// * `Err(StackError)` - If the MAC address could not be retrieved.
     pub fn get_winc_mac_address(
-        &mut self,
+        &self,
         #[cfg(test)] test_hook: bool,
     ) -> Result<MacAddress, StackError> {
         let mut op = SyncOp::get_winc_mac_address(
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn test_async_get_winc_mac_address_success() {
-        let mut client = make_test_client();
+        let client = make_test_client();
         let mac = client.get_winc_mac_address(true);
 
         assert!(mac.is_ok());
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn test_async_get_winc_mac_address_failure() {
-        let mut client = make_test_client();
+        let client = make_test_client();
         let mac = client.get_winc_mac_address(false);
 
         assert_eq!(

--- a/winc-rs/src/client/ethernet.rs
+++ b/winc-rs/src/client/ethernet.rs
@@ -65,12 +65,13 @@ impl<X: Xfer> WincClient<'_, X> {
     }
 }
 
+/// Implements `smoltcp::phy::Device` for `WincClient`.
 #[cfg(feature = "smoltcp")]
 mod smoltcp_impl {
     use super::{WincClient, Xfer};
     use crate::error;
     use crate::manager::{Manager, SOCKET_BUFFER_MAX_LENGTH};
-    use crate::net_ops::ethernet_receive::RxEthernetPacketInfo;
+    use crate::ops::net_ops::ethernet_receive::RxEthernetPacketInfo;
     use embedded_nal::nb;
     use smoltcp::{
         phy::{self, DeviceCapabilities, Medium},

--- a/winc-rs/src/client/ethernet.rs
+++ b/winc-rs/src/client/ethernet.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use super::{StackError, WincClient, Xfer};
+use crate::ops::module::SyncOp;
+use crate::ops::net_ops::ethernet_receive::RxEthernetPacketInfo;
+use core::time::Duration;
 use embedded_nal::nb;
-
-/// 1 second timeout to read an ethernet packet.
-const ETHERNET_RX_TIMEOUT_MSEC: u32 = 1000;
 
 impl<X: Xfer> WincClient<'_, X> {
     /// Tries to read an Ethernet packet from the module within a specified timeout.
@@ -27,10 +27,8 @@ impl<X: Xfer> WincClient<'_, X> {
     ///
     /// # Arguments
     ///
-    /// * `buffer` - An optional mutable slice used to store the received Ethernet packet.
-    ///   If `None`, the internal receive buffer with a capacity of `SOCKET_BUFFER_MAX_LENGTH`
-    ///   bytes is used.
-    /// * `timeout` - An optional timeout in milliseconds, to wait for an Ethernet packet.
+    /// * `buffer` - A mutable slice used to store the received Ethernet packet.
+    /// * `timeout` - An optional duration to wait for a packet.
     ///   If `None`, the default timeout value `ETHERNET_RX_TIMEOUT_MSEC` is used.
     ///
     /// # Returns
@@ -39,54 +37,12 @@ impl<X: Xfer> WincClient<'_, X> {
     /// * `Err(StackError)` - If an error occurs while reading the ethernet packet.
     pub fn read_ethernet_packet(
         &mut self,
-        buffer: Option<&mut [u8]>,
-        timeout: Option<u32>,
+        buffer: &mut [u8],
+        timeout: Option<Duration>,
     ) -> nb::Result<usize, StackError> {
-        match &mut self.callbacks.eth_rx_info {
-            None => {
-                self.callbacks.eth_rx_info = Some(None);
-                let timeout_ms = timeout.unwrap_or(ETHERNET_RX_TIMEOUT_MSEC);
-                // todo clean-up
-                self.operation_countdown = (timeout_ms * 1000) / self.poll_loop_delay_us;
-            }
-            Some(info) => {
-                if let Some(info) = info {
-                    let recv_buffer = match buffer {
-                        None => {
-                            self.callbacks.recv_buffer.fill(0);
-                            self.callbacks.recv_buffer.as_mut_slice()
-                        }
-                        Some(buffer) => buffer,
-                    };
-                    let len_to_read = recv_buffer.len().min(info.packet_size as usize);
-                    let rx_done = len_to_read >= info.packet_size as usize;
-                    self.manager.recv_ethernet_packet(
-                        info.hif_address + info.data_offset as u32,
-                        &mut recv_buffer[..len_to_read],
-                        rx_done,
-                    )?;
-                    // check if all data is read from the module.
-                    if rx_done {
-                        // no bytes left to read
-                        self.callbacks.eth_rx_info = None;
-                    } else {
-                        info.data_offset += len_to_read as u16;
-                        info.packet_size -= len_to_read as u16;
-                    }
-
-                    return Ok(len_to_read);
-                } else {
-                    self.delay_us(self.poll_loop_delay_us);
-                    if self.operation_countdown == 0 {
-                        self.callbacks.eth_rx_info = None;
-                        return Err(nb::Error::Other(StackError::GeneralTimeout));
-                    }
-                    self.operation_countdown -= 1;
-                }
-            }
-        }
-        self.dispatch_events()?;
-        Err(nb::Error::WouldBlock)
+        let timeout_ms: Option<u32> = timeout.map(|d| d.as_millis().min(u32::MAX as u128) as u32);
+        let mut op = RxEthernetPacketInfo::new(Some(buffer), timeout_ms);
+        self.poll_op(&mut op)
     }
 
     /// Sends an Ethernet packet to the module.
@@ -104,7 +60,8 @@ impl<X: Xfer> WincClient<'_, X> {
     /// * `Ok(())` - If packet is successfully sent to the module.
     /// * `Err(StackError)` - If an error occurred while sending the ethernet packet.
     pub fn send_ethernet_packet(&mut self, net_pkt: &[u8]) -> Result<(), StackError> {
-        Ok(self.manager.send_ethernet_packet(net_pkt)?)
+        let mut op = SyncOp::send_ethernet_packet(net_pkt);
+        self.poll_once(&mut op)
     }
 }
 
@@ -113,11 +70,13 @@ mod smoltcp_impl {
     use super::{WincClient, Xfer};
     use crate::error;
     use crate::manager::{Manager, SOCKET_BUFFER_MAX_LENGTH};
+    use crate::net_ops::ethernet_receive::RxEthernetPacketInfo;
     use embedded_nal::nb;
     use smoltcp::{
         phy::{self, DeviceCapabilities, Medium},
         time::Instant,
     };
+
     // 100 milliseconds timeout to wait for ethernet packet to arrive.
     const ETH_RECV_TIMEOUT_MSEC: u32 = 100;
 
@@ -149,7 +108,8 @@ mod smoltcp_impl {
             &mut self,
             _timestamp: Instant,
         ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-            let result = nb::block!(self.read_ethernet_packet(None, Some(ETH_RECV_TIMEOUT_MSEC)));
+            let mut rx_op = RxEthernetPacketInfo::new(None, Some(ETH_RECV_TIMEOUT_MSEC));
+            let result = nb::block!(self.poll_op(&mut rx_op));
 
             let Ok(read_length) = result else {
                 return None;
@@ -256,7 +216,7 @@ mod tests {
         };
         client.debug_callback = Some(&mut my_debug);
 
-        let result = nb::block!(client.read_ethernet_packet(Some(&mut rx_buffer), None));
+        let result = nb::block!(client.read_ethernet_packet(&mut rx_buffer, None));
 
         assert!(result.is_ok());
     }
@@ -265,9 +225,9 @@ mod tests {
     fn test_read_ethernet_packet_timeout() {
         let mut client = make_test_client();
         let mut rx_buffer = [0u8; 200];
-        let timeout = 1000 as u32;
+        let timeout = Some(Duration::from_millis(1000));
 
-        let result = nb::block!(client.read_ethernet_packet(Some(&mut rx_buffer), Some(timeout)));
+        let result = nb::block!(client.read_ethernet_packet(&mut rx_buffer, timeout));
 
         assert_eq!(result, Err(StackError::GeneralTimeout));
     }
@@ -277,14 +237,16 @@ mod tests {
         let mut client = make_test_client();
         client.callbacks.recv_buffer.fill(0xff);
         let rx_info = (1600 as u16, 111 as u16, 0xAABBCCDD as u32);
-        let timeout = 1000 as u32;
+        let timeout = Some(1000 as u32);
 
         let mut my_debug = |callbacks: &mut SocketCallbacks| {
             callbacks.on_eth(rx_info.0, rx_info.1, rx_info.2);
         };
         client.debug_callback = Some(&mut my_debug);
 
-        let result = nb::block!(client.read_ethernet_packet(None, Some(timeout)));
+        let mut op = RxEthernetPacketInfo::new(None, timeout);
+
+        let result = nb::block!(client.poll_op(&mut op));
 
         assert!(result.is_ok());
         assert!(client.callbacks.recv_buffer.iter().all(|&b| b == 0));

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -35,6 +35,8 @@ use requests::*;
 use responses::*;
 
 pub(crate) use constants::{BootMode, PRNG_DATA_LENGTH, SOCKET_BUFFER_MAX_LENGTH};
+#[cfg(feature = "embassy-net")]
+pub(crate) use net_types::MAX_OCTETS_IN_MAC_ADDRESS;
 
 #[cfg(feature = "ssl")]
 pub(crate) use self::{

--- a/winc-rs/src/manager.rs
+++ b/winc-rs/src/manager.rs
@@ -874,6 +874,39 @@ impl<X: Xfer> Manager<X> {
         }
     }
 
+    /// Registers a waker only if it is not already registered.
+    ///
+    /// # Arguments
+    ///
+    /// * `waker` - The task waker to register.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the waker was registered or was already registered.
+    /// * `StackError` - If too many wakers are already registered.
+    #[cfg(all(feature = "async", feature = "embassy-net"))]
+    pub(crate) fn register_waker_if_new(
+        &mut self,
+        waker: core::task::Waker,
+    ) -> Result<(), crate::StackError> {
+        // Already registered?
+        for slot in &self.wakers {
+            if let Some(ref stored) = slot {
+                if stored.will_wake(&waker) {
+                    return Ok(());
+                }
+            }
+        }
+        // Find empty slot
+        for slot in &mut self.wakers {
+            if slot.is_none() {
+                *slot = Some(waker);
+                return Ok(());
+            }
+        }
+        Err(crate::StackError::TooManyWakers)
+    }
+
     /// Sets the timeout (countdown) for the current Async/Sync operation.
     ///
     /// # Arguments

--- a/winc-rs/src/manager/net_types.rs
+++ b/winc-rs/src/manager/net_types.rs
@@ -34,8 +34,6 @@ const DEFAULT_AP_IP: u32 = 0xC0A80101;
 /// Maximum size of a point on an elliptic curve.
 #[cfg(feature = "experimental-ecc")]
 const ECC_POINT_MAX_SIZE: usize = 32;
-/// Maximum number of octets in Mac Address
-const MAX_OCTETS_IN_MAC_ADDRESS: usize = 6;
 /// Length for 104 bit string passphrase.
 const MAX_WEP_KEY_LEN: usize = 26;
 /// Length for 40 bit string passphrase.
@@ -43,6 +41,8 @@ const MAX_WEP_KEY_LEN: usize = 26;
 const MIN_WEP_KEY_LEN: usize = 10;
 /// Last byte of IPV4 address, total bytes: 4 (0-3)
 const LAST_BYTE_OF_IP_ADDRESS: usize = 3;
+/// Maximum number of octets in Mac Address
+pub(crate) const MAX_OCTETS_IN_MAC_ADDRESS: usize = 6;
 
 /// Device Domain name.
 pub type HostName = ArrayString<MAX_HOST_NAME_LEN>;

--- a/winc-rs/src/ops/module/mod.rs
+++ b/winc-rs/src/ops/module/mod.rs
@@ -63,6 +63,10 @@ enum SyncOpType<'a> {
         test_hook: bool,
         mac: Option<MacAddress>,
     },
+    #[cfg(feature = "ethernet")]
+    SendEthernetPacket {
+        packet: &'a [u8],
+    },
 }
 
 /// Container for managing synchronous operations.
@@ -273,6 +277,14 @@ impl<'a> SyncOp<'a> {
                 test_hook,
                 mac: None,
             },
+        }
+    }
+
+    #[cfg(feature = "ethernet")]
+    #[inline]
+    pub(crate) fn send_ethernet_packet(packet: &'a [u8]) -> Self {
+        Self {
+            op: SyncOpType::SendEthernetPacket { packet },
         }
     }
 
@@ -585,6 +597,8 @@ impl<'a, X: Xfer> OpImpl<X> for SyncOp<'a> {
                     test_hook,
                 )?);
             }
+            #[cfg(feature = "ethernet")]
+            SyncOpType::SendEthernetPacket { packet } => manager.send_ethernet_packet(packet)?,
         }
 
         Ok(Some(()))

--- a/winc-rs/src/ops/net_ops/ethernet_receive.rs
+++ b/winc-rs/src/ops/net_ops/ethernet_receive.rs
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ops::op::OpImpl;
+use crate::stack::StackError;
+use crate::transfer::Xfer;
+
+/// 1 second timeout to read an ethernet packet.
+const ETHERNET_RX_TIMEOUT_MSEC: u32 = 1000;
+
+pub(crate) struct RxEthernetPacketInfo<'a> {
+    buffer: Option<&'a mut [u8]>,
+    timeout: Option<u32>,
+}
+
+impl<'a> RxEthernetPacketInfo<'a> {
+    pub(crate) fn new(buffer: Option<&'a mut [u8]>, timeout: Option<u32>) -> Self {
+        Self { buffer, timeout }
+    }
+}
+
+impl<X: Xfer> OpImpl<X> for RxEthernetPacketInfo<'_> {
+    type Output = usize;
+    type Error = StackError;
+
+    /// Polls the internal state machine to receive an ethernet packet.
+    ///
+    /// # Arguments
+    ///
+    /// * `manager` - The stack manager handling low-level operations.
+    /// * `callbacks` - Socket callback handlers.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(output))` - Operation completed successfully.
+    /// * `Ok(None)` - Operation is still in progress.
+    /// * `Err(Self::Error)` - An error occurred while polling.
+    fn poll_impl(
+        &mut self,
+        manager: &mut crate::manager::Manager<X>,
+        callbacks: &mut crate::stack::socket_callbacks::SocketCallbacks,
+    ) -> Result<Option<Self::Output>, Self::Error> {
+        match &mut callbacks.eth_rx_info {
+            None => {
+                callbacks.eth_rx_info = Some(None);
+                let timeout_ms = self.timeout.unwrap_or(ETHERNET_RX_TIMEOUT_MSEC);
+                // todo clean-up
+                manager.set_operation_timeout((timeout_ms * 1000) / 100);
+            }
+            Some(info) => {
+                if let Some(info) = info {
+                    let recv_buffer = match self.buffer.as_mut() {
+                        None => {
+                            callbacks.recv_buffer.fill(0);
+                            callbacks.recv_buffer.as_mut_slice()
+                        }
+                        Some(buffer) => buffer,
+                    };
+                    let len_to_read = recv_buffer.len().min(info.packet_size as usize);
+                    let rx_done = len_to_read >= info.packet_size as usize;
+                    manager.recv_ethernet_packet(
+                        info.hif_address + info.data_offset as u32,
+                        &mut recv_buffer[..len_to_read],
+                        rx_done,
+                    )?;
+                    // check if all data is read from the module.
+                    if rx_done {
+                        // no bytes left to read
+                        callbacks.eth_rx_info = None;
+                    } else {
+                        info.data_offset += len_to_read as u16;
+                        info.packet_size -= len_to_read as u16;
+                    }
+
+                    return Ok(Some(len_to_read));
+                } else {
+                    let mut timeout = manager.get_operation_timeout();
+                    if timeout == 0 {
+                        callbacks.eth_rx_info = None;
+                        return Err(StackError::GeneralTimeout);
+                    }
+                    timeout -= 1;
+                    manager.set_operation_timeout(timeout);
+                }
+            }
+        }
+        Ok(None)
+    }
+}

--- a/winc-rs/src/ops/net_ops/ethernet_receive.rs
+++ b/winc-rs/src/ops/net_ops/ethernet_receive.rs
@@ -67,6 +67,11 @@ impl<X: Xfer> OpImpl<X> for RxEthernetPacketInfo<'_> {
                         }
                         Some(buffer) => buffer,
                     };
+                    // If no data is recevied from module, return early
+                    if recv_buffer.is_empty() {
+                        callbacks.eth_rx_info = None;
+                        return Ok(Some(0));
+                    }
                     let len_to_read = recv_buffer.len().min(info.packet_size as usize);
                     let rx_done = len_to_read >= info.packet_size as usize;
                     manager.recv_ethernet_packet(

--- a/winc-rs/src/ops/net_ops/mod.rs
+++ b/winc-rs/src/ops/net_ops/mod.rs
@@ -5,3 +5,6 @@ pub mod tcp_receive;
 pub mod tcp_send;
 pub mod udp_receive;
 pub mod udp_send;
+
+#[cfg(feature = "ethernet")]
+pub mod ethernet_receive;

--- a/winc-rs/src/stack/socket_callbacks.rs
+++ b/winc-rs/src/stack/socket_callbacks.rs
@@ -99,7 +99,7 @@ pub struct SystemTime {
 }
 
 pub(crate) struct ConnectionState {
-    conn_state: WifiConnState,
+    pub conn_state: WifiConnState,
     pub conn_error: Option<WifiConnError>,
     pub ip_conf: Option<crate::manager::IPConf>,
     system_time: Option<SystemTime>,


### PR DESCRIPTION
This PR adds support for Ethernet mode in async and implements an example using embassy-net to demonstrate the feature.

## Summary by Sourcery

Add async Ethernet-mode support with embassy-net integration and refactor PRNG and Ethernet operations into reusable ops, updating both sync and async clients and providing new examples.

New Features:
- Introduce async Ethernet packet send/receive APIs on AsyncClient, including an embassy-net driver implementation and a feather_async bypass_mode example.

Enhancements:
- Refactor Ethernet receive and send paths to use new shared op types, modernizing timeouts and buffer handling, and reuse them from smoltcp and async paths.
- Rename the internal net_ops module to ops and adjust references, and make the MAX_OCTETS_IN_MAC_ADDRESS constant reusable across modules.

Build:
- Update dependencies in feather_async Cargo.toml and add optional embassy-net feature wiring for external TCP stacks.

Tests:
- Extend unit tests for Ethernet paths, including Ethernet large buffers, empty buffers, and timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethernet/networking support for async client builds, including DHCP-based connectivity and packet send/receive capabilities.
  * Added a new embedded “Ethernet bypass mode” ping example with configurable Wi‑Fi credentials, target IP, ping count, and timeouts.
  * Added support for generating random bytes and retrieving the device MAC address in async flows.

* **Bug Fixes**
  * Improved Ethernet receive timeout handling and connection/waker behavior for more reliable networking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->