### PR TITLE
feat: net-stats — driver-level TCP/UDP + DNS counters

### DIFF
--- a/winc-rs/Cargo.toml
+++ b/winc-rs/Cargo.toml
@@ -79,6 +79,7 @@ experimental-ecc = ["ssl"] # Enables the ECDSA/ECDH functions. Depends on "ssl".
 ethernet = [] # Support for ethernet mode.
 smoltcp = ["ethernet", "dep:smoltcp"]
 embassy-net = ["ethernet", "dep:embassy-net-driver"]
+net-stats = [] # Driver-level TCP/UDP byte+op counters + DNS query count (WincClient::net_stats).
 
 # Todo: add feature flags to save binary space
 # - TCP

--- a/winc-rs/src/client.rs
+++ b/winc-rs/src/client.rs
@@ -21,6 +21,111 @@ pub use crate::stack::socket_callbacks::ClientSocketOp;
 use crate::stack::socket_callbacks::SocketCallbacks;
 pub use crate::stack::socket_callbacks::{Handle, PingResult};
 
+/// Driver-level network counters (feature `net-stats`).
+///
+/// The WINC runs the TCP/IP stack on-chip, so the host never sees L2 frames — these
+/// count what crosses the *driver API*: successful socket send/receive calls and their
+/// payload byte totals, split by transport. It is therefore app-layer TCP/UDP traffic
+/// (ARP/DHCP/DNS/ICMP happen inside the chip and are invisible), and `*_ops` are socket
+/// calls, **not** wire packets (the WINC fragments/reassembles internally). `dns_queries`
+/// counts host-name lookups issued. All counters wrap at `u32`.
+#[cfg(feature = "net-stats")]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+pub struct NetStats {
+    pub tcp_tx_bytes: u32,
+    pub tcp_rx_bytes: u32,
+    pub tcp_tx_ops: u32,
+    pub tcp_rx_ops: u32,
+    pub udp_tx_bytes: u32,
+    pub udp_rx_bytes: u32,
+    pub udp_tx_ops: u32,
+    pub udp_rx_ops: u32,
+    pub dns_queries: u32,
+}
+
+/// Process-global network counters (feature `net-stats`). Global rather than per-client
+/// so they can be read without borrowing the [`WincClient`] — the normal case is one WINC
+/// per system. Incremented from the socket send/receive paths.
+#[cfg(feature = "net-stats")]
+pub(crate) mod counters {
+    use super::NetStats;
+    use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
+
+    static TCP_TX_BYTES: AtomicU32 = AtomicU32::new(0);
+    static TCP_RX_BYTES: AtomicU32 = AtomicU32::new(0);
+    static TCP_TX_OPS: AtomicU32 = AtomicU32::new(0);
+    static TCP_RX_OPS: AtomicU32 = AtomicU32::new(0);
+    static UDP_TX_BYTES: AtomicU32 = AtomicU32::new(0);
+    static UDP_RX_BYTES: AtomicU32 = AtomicU32::new(0);
+    static UDP_TX_OPS: AtomicU32 = AtomicU32::new(0);
+    static UDP_RX_OPS: AtomicU32 = AtomicU32::new(0);
+    static DNS_QUERIES: AtomicU32 = AtomicU32::new(0);
+
+    pub(crate) fn tcp_tx(bytes: usize) {
+        TCP_TX_BYTES.fetch_add(bytes as u32, Relaxed);
+        TCP_TX_OPS.fetch_add(1, Relaxed);
+    }
+    pub(crate) fn tcp_rx(bytes: usize) {
+        TCP_RX_BYTES.fetch_add(bytes as u32, Relaxed);
+        TCP_RX_OPS.fetch_add(1, Relaxed);
+    }
+    pub(crate) fn udp_tx(bytes: usize) {
+        UDP_TX_BYTES.fetch_add(bytes as u32, Relaxed);
+        UDP_TX_OPS.fetch_add(1, Relaxed);
+    }
+    pub(crate) fn udp_rx(bytes: usize) {
+        UDP_RX_BYTES.fetch_add(bytes as u32, Relaxed);
+        UDP_RX_OPS.fetch_add(1, Relaxed);
+    }
+    pub(crate) fn dns_query() {
+        DNS_QUERIES.fetch_add(1, Relaxed);
+    }
+
+    pub(crate) fn snapshot() -> NetStats {
+        NetStats {
+            tcp_tx_bytes: TCP_TX_BYTES.load(Relaxed),
+            tcp_rx_bytes: TCP_RX_BYTES.load(Relaxed),
+            tcp_tx_ops: TCP_TX_OPS.load(Relaxed),
+            tcp_rx_ops: TCP_RX_OPS.load(Relaxed),
+            udp_tx_bytes: UDP_TX_BYTES.load(Relaxed),
+            udp_rx_bytes: UDP_RX_BYTES.load(Relaxed),
+            udp_tx_ops: UDP_TX_OPS.load(Relaxed),
+            udp_rx_ops: UDP_RX_OPS.load(Relaxed),
+            dns_queries: DNS_QUERIES.load(Relaxed),
+        }
+    }
+    pub(crate) fn reset() {
+        for a in [
+            &TCP_TX_BYTES,
+            &TCP_RX_BYTES,
+            &TCP_TX_OPS,
+            &TCP_RX_OPS,
+            &UDP_TX_BYTES,
+            &UDP_RX_BYTES,
+            &UDP_TX_OPS,
+            &UDP_RX_OPS,
+            &DNS_QUERIES,
+        ] {
+            a.store(0, Relaxed);
+        }
+    }
+}
+
+/// Read a snapshot of the driver-level network counters (feature `net-stats`).
+///
+/// Free-function form of [`WincClient::net_stats`], readable even while the client is
+/// borrowed elsewhere (e.g. by a TLS stream). See [`NetStats`].
+#[cfg(feature = "net-stats")]
+pub fn net_stats() -> NetStats {
+    counters::snapshot()
+}
+
+/// Reset all driver-level network counters to zero (feature `net-stats`).
+#[cfg(feature = "net-stats")]
+pub fn reset_net_stats() {
+    counters::reset()
+}
+
 /// Client for the WincWifi chip.
 ///
 /// This manages the state of the chip and
@@ -66,6 +171,23 @@ impl<X: Xfer> WincClient<'_, X> {
             #[cfg(test)]
             debug_callback: None,
         }
+    }
+
+    /// Snapshot of the driver-level network counters (feature `net-stats`).
+    ///
+    /// Equivalent to the free [`net_stats()`](crate::net_stats) function — the counters
+    /// are process-global (one WINC per system), so they can also be read without a
+    /// borrow of the client (useful when the client is borrowed elsewhere, e.g. by a
+    /// TLS stream). See [`NetStats`] for exactly what is (and isn't) counted.
+    #[cfg(feature = "net-stats")]
+    pub fn net_stats(&self) -> NetStats {
+        net_stats()
+    }
+
+    /// Reset all network counters to zero (feature `net-stats`).
+    #[cfg(feature = "net-stats")]
+    pub fn reset_net_stats(&mut self) {
+        reset_net_stats()
     }
     // Todo: remove this
     fn delay_us(&mut self, delay: u32) {

--- a/winc-rs/src/client/dns.rs
+++ b/winc-rs/src/client/dns.rs
@@ -24,7 +24,11 @@ impl<X: Xfer> Dns for WincClient<'_, X> {
         // Initialize DNS op if not already started
         if self.dns_op.is_none() {
             match DnsOp::new(hostname, Self::DNS_TIMEOUT) {
-                Ok(dns_op) => self.dns_op = Some(dns_op),
+                Ok(dns_op) => {
+                    self.dns_op = Some(dns_op);
+                    #[cfg(feature = "net-stats")]
+                    crate::client::counters::dns_query();
+                }
                 Err(e) => return Err(nb::Error::Other(e)),
             }
         }

--- a/winc-rs/src/client/tcp_stack.rs
+++ b/winc-rs/src/client/tcp_stack.rs
@@ -71,6 +71,10 @@ impl<X: Xfer> embedded_nal::TcpClientStack for WincClient<'_, X> {
     ) -> Result<usize, nb::Error<<Self as TcpClientStack>::Error>> {
         let mut op = TcpSendOp::new(*socket, data);
         let res = self.poll_op(&mut op);
+        #[cfg(feature = "net-stats")]
+        if let Ok(n) = res {
+            crate::client::counters::tcp_tx(n);
+        }
         self.test_hook();
         res
     }
@@ -85,6 +89,12 @@ impl<X: Xfer> embedded_nal::TcpClientStack for WincClient<'_, X> {
     ) -> Result<usize, nb::Error<<Self as TcpClientStack>::Error>> {
         let mut op = TcpReceiveOp::new(*socket, data);
         let res = self.poll_op(&mut op);
+        #[cfg(feature = "net-stats")]
+        if let Ok(n) = res {
+            if n > 0 {
+                crate::client::counters::tcp_rx(n);
+            }
+        }
         self.test_hook();
         res
     }

--- a/winc-rs/src/client/udp_stack.rs
+++ b/winc-rs/src/client/udp_stack.rs
@@ -62,6 +62,10 @@ impl<X: Xfer> WincClient<'_, X> {
             Ok(None) => Err(nb::Error::WouldBlock),
             Err(e) => Err(nb::Error::Other(e)),
         };
+        #[cfg(feature = "net-stats")]
+        if result.is_ok() {
+            crate::client::counters::udp_tx(data.len());
+        }
         self.test_hook();
         result
     }
@@ -148,6 +152,10 @@ impl<X: Xfer> UdpClientStack for WincClient<'_, X> {
             Ok(None) => Err(nb::Error::WouldBlock),
             Err(e) => Err(nb::Error::Other(e)),
         };
+        #[cfg(feature = "net-stats")]
+        if let Ok((len, _)) = result {
+            crate::client::counters::udp_rx(len);
+        }
         self.test_hook();
         result
     }

--- a/winc-rs/src/lib.rs
+++ b/winc-rs/src/lib.rs
@@ -85,6 +85,8 @@ pub use transfer::Xfer as Transfer;
 pub use client::PingResult;
 pub use client::StackError;
 pub use client::WincClient;
+#[cfg(feature = "net-stats")]
+pub use client::{net_stats, reset_net_stats, NetStats};
 pub use manager::AuthType;
 pub use manager::ConnectionInfo;
 pub use manager::FirmwareInfo;


### PR DESCRIPTION
**Draft** — opening for early review. Validated on hardware, but I'd like maintainer input on the API shape before finalizing.

## What
A `net-stats` feature (off by default, zero cost when unused) that counts what the chip's SPI protocol doesn't expose: successful socket send/receive calls and their payload byte totals, split TCP vs UDP, plus a DNS-query count.

The WINC runs the TCP/IP stack on-chip, so the host can't see L2 frames the way a smoltcp host can — but the **driver** sees every socket op, so we can count there.

## API
- `NetStats { tcp/udp _tx/_rx _bytes/_ops, dns_queries }` (`Copy`/`Default`).
- `WincClient::net_stats()` / `reset_net_stats()`.
- Free `wincwifi::net_stats()` / `reset_net_stats()` — read **without borrowing** the client. This matters when something borrows the whole `WincClient` for a session (e.g. a TLS stream over its `TcpClientStack`), where a `&self` method can't be called mid-session.

Counters are process-global atomics (one WINC per system), which is what lets the free readers work.

## Honest semantics (documented on `NetStats`)
- App-layer TCP/UDP payload, **not** L2 — ARP/DHCP/DNS/ICMP happen inside the chip and are invisible.
- `*_ops` are socket send/receive *calls*, **not** wire packets (the WINC fragments/reassembles internally).

## Where it counts
TCP send/receive (`tcp_stack.rs`), UDP send/receive (`udp_stack.rs`, via `send_udp_inner`), DNS query issue (`dns.rs`) — all on success only.

## Tested
Consumed downstream by a krabitls-TLS-over-WINC AWS IoT shadow client on a SAM4S: the counters grow live per shadow report (read mid-session via the free fn) and match expectations — TCP-only traffic to AWS, `dns_queries=1` for the endpoint resolve, `udp_*` zero.

## Open questions for review
- Global atomics vs a per-client field? Global was chosen so the free readers work under a borrow — happy to switch if a per-client design is preferred.
- Naming: `*_ops` vs something clearer.
- Should the DNS count live here, or generalize to other manager requests?

## Summary by Sourcery

Add an optional driver-level network statistics feature that exposes TCP/UDP traffic and DNS query counters via both client methods and free functions.

New Features:
- Introduce a NetStats struct capturing TCP/UDP transmit/receive byte and operation counts plus DNS query totals.
- Expose process-global network counters through WincClient::net_stats/reset_net_stats and corresponding free functions for non-borrowing access.
- Wire TCP, UDP, and DNS code paths to increment counters on successful operations when the net-stats feature is enabled.

Enhancements:
- Export the net-stats API from the crate root and gate it behind a new Cargo feature flag to keep the feature opt-in and zero-cost when disabled.

Build:
- Add a net-stats Cargo feature to control inclusion of driver-level network counters.